### PR TITLE
[FIX] Multi company

### DIFF
--- a/helpdesk_mgmt/data/helpdesk_data.xml
+++ b/helpdesk_mgmt/data/helpdesk_data.xml
@@ -28,6 +28,7 @@
       <field name="code">helpdesk.ticket.sequence</field>
       <field name="prefix">HT</field>
       <field name="padding">5</field>
+      <field name="company_id"/>
     </record>
     <!-- Stages -->
     <record id="helpdesk_ticket_stage_new" model="helpdesk.ticket.stage">
@@ -35,18 +36,21 @@
       <field name="name">New</field>
       <field name="unattended">True</field>
       <field name="closed">False</field>
+      <field name="company_id"/>
     </record>
     <record id="helpdesk_ticket_stage_in_progress" model="helpdesk.ticket.stage">
       <field name="sequence">2</field>
       <field name="name">In Progress</field>
       <field name="unattended">False</field>
       <field name="closed">False</field>
+      <field name="company_id"/>
     </record>
     <record id="helpdesk_ticket_stage_awaiting" model="helpdesk.ticket.stage">
       <field name="sequence">3</field>
       <field name="name">Awaiting</field>
       <field name="unattended">False</field>
       <field name="closed">False</field>
+      <field name="company_id"/>
     </record>
     <record id="helpdesk_ticket_stage_done" model="helpdesk.ticket.stage">
       <field name="sequence">3</field>
@@ -54,6 +58,7 @@
       <field name="unattended">False</field>
       <field name="closed">True</field>
       <field name="fold">True</field>
+      <field name="company_id"/>
     </record>
     <record id="helpdesk_ticket_stage_cancelled" model="helpdesk.ticket.stage">
       <field name="sequence">4</field>
@@ -61,6 +66,7 @@
       <field name="unattended">False</field>
       <field name="closed">True</field>
       <field name="fold">True</field>
+      <field name="company_id"/>
     </record>
     <!-- Channels -->
     <record id="helpdesk_ticket_channel_web" model="helpdesk.ticket.channel">

--- a/helpdesk_mgmt/models/helpdesk_ticket.py
+++ b/helpdesk_mgmt/models/helpdesk_ticket.py
@@ -111,9 +111,11 @@ class HelpdeskTicket(models.Model):
     @api.model
     def create(self, vals):
         if vals.get('number', '/') == '/':
-            vals['number'] = self.env['ir.sequence'].next_by_code(
-                'helpdesk.ticket.sequence'
-            ) or '/'
+            seq = self.env['ir.sequence']
+            if 'company_id' in vals:
+                seq = seq.with_context(force_company=vals['company_id'])
+            vals['number'] = seq.next_by_code(
+                'helpdesk.ticket.sequence') or '/'
         res = super().create(vals)
 
         # Check if mail to the user has to be sent

--- a/helpdesk_mgmt/views/helpdesk_ticket_view.xml
+++ b/helpdesk_mgmt/views/helpdesk_ticket_view.xml
@@ -79,7 +79,7 @@
                             <field name="user_id" options='{"always_reload": True}'/>
 
                             <field name="priority" widget="priority"/>
-                            <field name="company_id" readonly="1" groups="base.group_multi_company"/>
+                            <field name="company_id" options="{'no_create': True}" groups="base.group_multi_company"/>
                             <field name="create_date"/>
                             <field name="channel_id"/>
                         </group>


### PR DESCRIPTION
1.- Added company_id field (empty) to the initial creation of stages (data folder). This allows to use the initial stages with multi-company, so they are not created with any company.

2.- Added company_id field to the sequence. The purpose of this is to make posible having different sequences in each company.

3.- Refactored the "create" method to make posible different sequences.

4.- Deleted "readonly" attribute of company_id in the helpdesk.ticket form. (As it is in every other Odoo module.)

5.- Added a security rule to make posible to Users to see all tickets. (There is other group "User: Personal tickets" which won't have this permission.)