### PR TITLE
[IMP] helpdesk_mgmt: at creation last_stage_update use actual now

### DIFF
--- a/helpdesk_mgmt/models/helpdesk_ticket.py
+++ b/helpdesk_mgmt/models/helpdesk_ticket.py
@@ -43,7 +43,7 @@ class HelpdeskTicket(models.Model):
 
     last_stage_update = fields.Datetime(
         string='Last Stage Update',
-        default=fields.Datetime.now(),
+        default=fields.Datetime.now,
     )
     assigned_date = fields.Datetime(string='Assigned Date')
     closed_date = fields.Datetime(string='Closed Date')

--- a/helpdesk_mgmt/tests/test_helpdesk_ticket.py
+++ b/helpdesk_mgmt/tests/test_helpdesk_ticket.py
@@ -1,3 +1,4 @@
+import time
 from odoo.tests import common
 
 
@@ -29,6 +30,8 @@ class TestHelpdeskTicket(common.SavepointCase):
                          'Helpdesk Ticket: No closed date '
                          'should be set for a non closed '
                          'ticket.')
+
+        time.sleep(1)
 
         self.ticket.write({
             'stage_id': self.stage_closed.id,


### PR DESCRIPTION
In helpdesk ticket, default last_stage_update use actual now instead of server start time.
More details in #55 