### PR TITLE
11.0 add searchbar input

### DIFF
--- a/helpdesk_mgmt/controllers/myaccount.py
+++ b/helpdesk_mgmt/controllers/myaccount.py
@@ -6,6 +6,8 @@ from odoo.addons.portal.controllers.portal import CustomerPortal
 from odoo.addons.portal.controllers.portal import pager as portal_pager
 from odoo.exceptions import AccessError
 
+from odoo.osv.expression import OR
+
 
 class CustomerPortal(CustomerPortal):
 
@@ -27,6 +29,11 @@ class CustomerPortal(CustomerPortal):
             raise
         return ticket_sudo
 
+    def _message_content_field_exists(self):
+        base_search_module = request.env['ir.module.module'].sudo().search([
+            ('name', '=', 'base_search_mail_content')])
+        return (base_search_module and base_search_module.state == 'installed')
+
     @http.route(
         ['/my/tickets', '/my/tickets/page/<int:page>'],
         type='http',
@@ -40,6 +47,8 @@ class CustomerPortal(CustomerPortal):
             date_end=None,
             sortby=None,
             filterby=None,
+            search=None,
+            search_in='all',
             **kw):
         values = self._prepare_portal_layout_values()
         HelpdesTicket = request.env['helpdesk.ticket']
@@ -53,6 +62,51 @@ class CustomerPortal(CustomerPortal):
             'update': {'label': _('Last Stage Update'),
                        'order': 'last_stage_update desc'},
         }
+
+        # search input (text)
+        searchbar_inputs = {
+            'name': {'input': 'name',
+                     'label': _('Search in Names')},
+            'description': {'input': 'description',
+                            'label': _('Search in Descriptions')},
+            'user_id': {'input': 'user',
+                        'label': _('Search in Assigned users')},
+            'category_id': {'input': 'category',
+                            'label': _('Search in Categories')},
+        }
+        if self._message_content_field_exists():
+            searchbar_inputs['message_content'] = {
+                'input': 'message_content',
+                'label': _('Search in Messages')
+            }
+        searchbar_meta_inputs = {
+            'content': {'input': 'content', 'label': _('Search in Content')},
+            'all': {'input': 'all', 'label': _('Search in All')},
+        }
+
+        if search and search_in:
+            search_domain = []
+            if search_in == 'content':
+                search_domain = ['|', ('name', 'ilike', search),
+                                 ('description', 'ilike', search)]
+
+                if 'message_content' in searchbar_inputs:
+                    search_domain = OR([
+                        search_domain,
+                        [('message_content', 'ilike', search)]
+                    ])
+            else:
+                for search_property in [
+                        k
+                        for (k, v) in searchbar_inputs.items()
+                        if search_in in (v['input'], 'all')
+                ]:
+                    search_domain = OR(
+                        [search_domain, [(search_property, 'ilike', search)]])
+            domain += search_domain
+        searchbar_inputs.update(searchbar_meta_inputs)
+
+        # search filters (by stage)
         searchbar_filters = {'all': {'label': _('All'), 'domain': []}}
         for stage in request.env['helpdesk.ticket.stage'].search([]):
             searchbar_filters.update({
@@ -94,6 +148,8 @@ class CustomerPortal(CustomerPortal):
             'pager': pager,
             'default_url': '/my/tickets',
             'searchbar_sortings': searchbar_sortings,
+            'searchbar_inputs': searchbar_inputs,
+            'search_in': search_in,
             'sortby': sortby,
             'no_breadcrumbs': False,
             'searchbar_filters': searchbar_filters,

--- a/helpdesk_mgmt/i18n/helpdesk_mgmt.pot
+++ b/helpdesk_mgmt/i18n/helpdesk_mgmt.pot
@@ -920,3 +920,37 @@ msgstr ""
 msgid "assigned user"
 msgstr ""
 
+#. module: helpdesk_mgmt
+#: code:addons/helpdesk_mgmt/controllers/myaccount.py:83
+msgid "Search in All"
+msgstr ""
+
+#. module: helpdesk_mgmt
+#: code:addons/helpdesk_mgmt/controllers/myaccount.py:84
+msgid "Search in Content"
+msgstr ""
+
+#. module: helpdesk_mgmt
+#: code:addons/helpdesk_mgmt/controllers/myaccount.py:69
+msgid "Search in Names"
+msgstr ""
+
+#. module: helpdesk_mgmt
+#: code:addons/helpdesk_mgmt/controllers/myaccount.py:71
+msgid "Search in Descriptions"
+msgstr ""
+
+#. module: helpdesk_mgmt
+#: code:addons/helpdesk_mgmt/controllers/myaccount.py:73
+msgid "Search in Assigned users"
+msgstr ""
+
+#. module: helpdesk_mgmt
+#: code:addons/helpdesk_mgmt/controllers/myaccount.py:75
+msgid "Search in Categories"
+msgstr ""
+
+#. module: helpdesk_mgmt
+#: code:addons/helpdesk_mgmt/controllers/myaccount.py:80
+msgid "Search in Messages"
+msgstr ""


### PR DESCRIPTION
See https://github.com/OCA/helpdesk/issues/64 as original issue.

This PR add search bar text input to portal ticket list.
Searchable fields are : name; description; user; category; (optionnally message content)
2 meta fields extend searchable fields : All (lookup all searchable fields); Content (name + description + optionally message content) 

Searching in message content is enabled by installing the module [base_search_mail_content](https://github.com/OCA/social/tree/11.0/base_search_mail_content).