### PR TITLE
Linking tickets to other documents

### DIFF
--- a/helpdesk_mgmt/__manifest__.py
+++ b/helpdesk_mgmt/__manifest__.py
@@ -32,6 +32,7 @@
         'views/helpdesk_ticket_tag_view.xml',
         'views/helpdesk_ticket_view.xml',
         'views/helpdesk_dashboard_view.xml',
+        'views/res_config_settings.xml',
     ],
     'demo': [
         'demo/helpdesk_demo.xml',

--- a/helpdesk_mgmt/models/__init__.py
+++ b/helpdesk_mgmt/models/__init__.py
@@ -5,3 +5,4 @@ from . import helpdesk_ticket_channel
 from . import helpdesk_ticket_category
 from . import helpdesk_ticket_team
 from . import res_partner 
+from . import res_config_settings

--- a/helpdesk_mgmt/models/helpdesk_ticket.py
+++ b/helpdesk_mgmt/models/helpdesk_ticket.py
@@ -76,6 +76,23 @@ class HelpdeskTicket(models.Model):
         domain=[('res_model', '=', 'helpdesk.ticket')],
         string="Media Attachments")
 
+    link_settings = fields.Boolean(compute="_get_configuration")
+
+    link_docs = fields.Reference(
+        string='Related Document', selection='get_referencable_models')
+
+    def _get_configuration(self):
+        irDefault = self.env['ir.default'].sudo()
+        self.link_settings = irDefault.get('res.config.settings', 'link_docs')
+
+    @api.model
+    def get_referencable_models(self):
+        irDefault = self.env['ir.default'].sudo()
+        ids = irDefault.get('res.config.settings', 'related_models')
+        models = self.env['res.request.link'].search(
+            [('id', 'in', ids)])
+        return[(x.object, x.name) for x in models]
+
     def send_user_mail(self):
         self.env.ref('helpdesk_mgmt.assignment_email_template'). \
             send_mail(self.id)

--- a/helpdesk_mgmt/models/res_config_settings.py
+++ b/helpdesk_mgmt/models/res_config_settings.py
@@ -1,0 +1,40 @@
+from odoo import api, fields, models
+# from odoo.exceptions import UserError, ValidationError
+import logging
+_logger = logging.getLogger(__name__)
+
+
+class ResConfigSettings(models.TransientModel):
+    _inherit = 'res.config.settings'
+
+    link_docs = fields.Boolean(
+        string='Link Documents', default="False")
+
+    related_models = fields.Many2many(
+        comodel_name='res.request.link',
+        string='Select Models')
+
+    @api.onchange('link_docs')
+    def _on_change_link_docs(self):
+        if not self.link_docs:
+            self.related_models = []
+
+    @api.multi
+    def set_values(self):
+        super(ResConfigSettings, self).set_values()
+        IrDefault = self.env['ir.default'].sudo()
+        IrDefault.set('res.config.settings', 'link_docs', self.link_docs)
+        IrDefault.set('res.config.settings', 'related_models',
+                      self.related_models.ids)
+        return True
+
+    @api.model
+    def get_values(self):
+        res = super(ResConfigSettings, self).get_values()
+        IrDefault = self.env['ir.default'].sudo()
+        res.update({
+            'link_docs': IrDefault.get('res.config.settings', 'link_docs'),
+            'related_models': IrDefault.get(
+                'res.config.settings', 'related_models'),
+        })
+        return res

--- a/helpdesk_mgmt/views/helpdesk_ticket_menu.xml
+++ b/helpdesk_mgmt/views/helpdesk_ticket_menu.xml
@@ -68,15 +68,14 @@
             <field name="view_type">form</field>
         </record>
 
-        <!-- #TODO -->
-        <!-- <record id="helpdesk_ticket_config_settings_action" model="ir.actions.act_window">
+        <record id="helpdesk_ticket_config_settings_action" model="ir.actions.act_window">
             <field name="name">Configure Helpdesk</field>
             <field name="type">ir.actions.act_window</field>
             <field name="res_model">res.config.settings</field>
             <field name="view_mode">form</field>
             <field name="target">inline</field>
-            <field name="context">{'module' : 'helpdesk'}</field>
-        </record> -->
+            <field name="context">{'module' : 'helpdesk_mgmt'}</field>
+        </record>
 
         <!-- Menus -->
         <menuitem id="helpdesk_ticket_main_menu" name="Helpdesk" sequence="16"
@@ -99,9 +98,8 @@
             parent="helpdesk_ticket_main_menu" sequence="35"
             groups="group_helpdesk_manager"/>
 
-        <!-- #TODO -->
-        <!-- <menuitem id="helpdesk_ticket_config_settings_menu" name="Settings"
-            parent="helpdesk_ticket_config_main_menu" action="helpdesk_ticket_config_settings_action" sequence="1"/> -->
+        <menuitem id="helpdesk_ticket_config_settings_menu" name="Settings"
+            parent="helpdesk_ticket_config_main_menu" action="helpdesk_ticket_config_settings_action" sequence="1"/>
 
         <menuitem id="helpdesk_ticket_channel_menu" name="Channels" parent="helpdesk_ticket_config_main_menu"
             action="helpdesk_ticket_channel_action" sequence="5"/>

--- a/helpdesk_mgmt/views/helpdesk_ticket_view.xml
+++ b/helpdesk_mgmt/views/helpdesk_ticket_view.xml
@@ -90,6 +90,10 @@
                             <field name="category_id"/>
                             <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color', 'no_create_edit': True}"/>
                         </group>
+                        <group>
+                          <field name="link_settings" invisible='1'/>
+                          <field name="link_docs" attrs="{'invisible': [('link_settings', '=', False)]}"/>
+                        </group>
                     </group>
                     <group>
                         <notebook>

--- a/helpdesk_mgmt/views/res_config_settings.xml
+++ b/helpdesk_mgmt/views/res_config_settings.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+  <data>
+    <record id="res_config_settings_view_form_inherit" model="ir.ui.view">
+      <field name="name">res.config.settings.view.form.inherit</field>
+      <field name="model">res.config.settings</field>
+      <field name="inherit_id" ref="base.res_config_settings_view_form"/>
+      <field name="arch" type="xml">
+        <xpath expr="//div[hasclass('settings')]" position="inside">
+          <div class="app_settings_block" data-string="Helpdesk" string="Helpdesk" data-key="helpdesk_mgmt" groups="helpdesk_mgmt.group_helpdesk_manager">
+            <h2>Link Documents</h2>
+            <div class="row mt16 o_settings_container">
+              <div class="col-xs-12 col-md-6 o_setting_box" id="link_doc_setting">
+                <div class="o_setting_left_pane">
+                  <field name="link_docs"/>
+                </div>
+                <div class="o_setting_right_pane">
+                  <label for="link_docs"/>
+                  <div class="text-muted">
+                    It allows linking the tickets with the selected documents
+                  </div>
+                  <div class="content-group" attrs="{'invisible': [('link_docs', '=', False)]}">
+                    <div class="mt16">
+                      <field name="related_models" widget="many2many_tags" options="{'no_create': True}"/>
+                    </div>
+                  </div>
+                  <div attrs="{'invisible': [('link_docs', '=', False)]}">
+                    <button type="action" name="" string="Add new models" class="btn-link" icon="fa-arrow-right"/>
+                  </div>
+            </div>
+          </div>
+        </div>
+      </div>
+        </xpath>
+      </field>
+    </record>
+  </data>
+</odoo>


### PR DESCRIPTION
- Added helpdesk settings.
- Added a new menu to access the settings.
- Added two fields in settings to enable or disable this option and select the models to relate.
- Added new field in the ticket to relate this with other documents.
