### PR TITLE
[12.0] Kanban ticket view improvement

### DIFF
--- a/helpdesk_mgmt/models/helpdesk_ticket.py
+++ b/helpdesk_mgmt/models/helpdesk_ticket.py
@@ -75,6 +75,11 @@ class HelpdeskTicket(models.Model):
         'ir.attachment', 'res_id',
         domain=[('res_model', '=', 'helpdesk.ticket')],
         string="Media Attachments")
+    color = fields.Integer(string='Color Index')
+    kanban_state = fields.Selection([
+        ('normal', 'Default'),
+        ('done', 'Ready for next stage'),
+        ('blocked', 'Blocked')], string='Kanban State')
 
     def send_user_mail(self):
         self.env.ref('helpdesk_mgmt.assignment_email_template'). \

--- a/helpdesk_mgmt/readme/CONTRIBUTORS.rst
+++ b/helpdesk_mgmt/readme/CONTRIBUTORS.rst
@@ -3,6 +3,7 @@
   * Carlos Martínez
   * Catalin Airimitoaie
   * Álvaro López
+  * Samuel Calvo
 
 * `Adaptive City <https://www.adaptivecity.com>`_:
 
@@ -30,4 +31,3 @@
 
   * Marcel Savegnago
   * Eduardo Aparício
-

--- a/helpdesk_mgmt/views/helpdesk_ticket_view.xml
+++ b/helpdesk_mgmt/views/helpdesk_ticket_view.xml
@@ -165,44 +165,63 @@
     </record>
 
     <record id="view_helpdesk_ticket_kanban" model="ir.ui.view">
-        <field name="name">helpdesk.ticket.kanban</field>
-        <field name="model">helpdesk.ticket</field>
-        <field name="priority" eval="100"/>
-        <field name="arch" type="xml">
-            <kanban class="o_kanban_mobile" archivable="false"  default_group_by="stage_id" >
-                <field name="number"/>
-                <field name="name"/>
-                <field name="partner_name"/>
-                <field name="user_id"/>
-                <field name="stage_id"/>
-                <field name="priority" widget="priority"/>
-                <field name="assigned_date"/>
-                <templates>
-                    <t t-name="kanban-box">
-                        <div t-attf-class="oe_kanban_content oe_kanban_global_click">
-                            <div>
-                                <h2><field name="number"/> - <field name="name"/></h2>
-                            </div>
-                            <div>
-                                <span class="o_kanban_record_subtitle"><field name="partner_id"/></span>
-                            </div>
-                            <div>
-                                <field name="assigned_date"/>
-                            </div>
-                            <div class="o_kanban_record_bottom">
-                                <div class="oe_kanban_bottom_left">
-                                    <field name="priority" widget="priority"/>
-                                    <div class="o_kanban_inline_block">
-                                        <field name="activity_ids" widget="kanban_activity"/>
-                                    </div>
-                                </div>
-                            </div>
+      <field name="name">helpdesk.ticket.kanban</field>
+      <field name="model">helpdesk.ticket</field>
+      <field name="priority" eval="100"/>
+      <field name="arch" type="xml">
+          <kanban class="o_kanban_mobile" archivable="false"  default_group_by="stage_id" >
+              <field name="number"/>
+              <field name="name"/>
+              <field name="partner_name"/>
+              <field name="user_id"/>
+              <field name="color"/>
+              <field name="stage_id"/>
+              <field name="priority" widget="priority"/>
+              <field name="assigned_date"/>
+              <progressbar field="activity_state" colors="{&quot;planned&quot;: &quot;success&quot;, &quot;today&quot;: &quot;warning&quot;, &quot;overdue&quot;: &quot;danger&quot;}"/>
+              <templates>
+                  <t t-name="kanban-box">
+                    <div t-attf-class="oe_kanban_color_#{kanban_getcolor(record.color.raw_value)} oe_kanban_content oe_kanban_global_click">
+                        <div class="o_dropdown_kanban dropdown" groups="base.group_user">
+                            <a class="dropdown-toggle btn" role="button" data-toggle="dropdown" href="#">
+                                <span class="fa fa-ellipsis-v" aria-hidden="true"/>
+                            </a>
+                            <ul class="dropdown-menu" role="menu" aria-labelledby="dLabel">
+                                <li t-if="widget.editable"><a type="edit">Edit</a></li>
+                                <li t-if="widget.deletable"><a type="delete">Delete</a></li>
+                                <li class="divider"/>
+                                <li>
+                                    <ul class="oe_kanban_colorpicker" data-field="color"/>
+                                </li>
+                            </ul>
                         </div>
-                    </t>
-                </templates>
-            </kanban>
-        </field>
-    </record>
+                          <div class="o_kanban_record_top">
+                            <div class="o_kanban_record_headings">
+                              <strong class="o_kanban_record_title" style="font-weight: bold"><field name="number"/> - <field name="name"/></strong>
+                              <small class="o_kanban_record_subtitle text-muted">
+                                <field name="partner_id"/>
+                              </small>
+                            </div>
+                          </div>
+                          <div class="o_kanban_record_body">
+                            <field name="priority" widget="priority"/>
+                            <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color'}"/>
+                          </div>
+                          <div class="o_kanban_record_bottom">
+                            <div class="oe_kanban_bottom_left"/>
+                            <div class="oe_kanban_bottom_right">
+                              <field name="activity_ids" widget="kanban_activity" related="activity_state"/>
+                              <field name="kanban_state" widget="state_selection"/>
+                              <field name="activity_state" invisible="1"/>
+                              <img t-att-src="kanban_image('res.users', 'image_small', record.user_id.raw_value)" t-att-title="record.user_id.value" width="24" height="24" class="oe_kanban_avatar" t-att-alt="Assigned user image"/>
+                            </div>
+                          </div>
+                      </div>
+                  </t>
+              </templates>
+          </kanban>
+      </field>
+  </record>
     <record id="helpdesk_ticket_views_pivot" model="ir.ui.view">
         <field name="name">helpdesk.ticket.view.pivot</field>
         <field name="model">helpdesk.ticket</field>


### PR DESCRIPTION
Improvements added to the kanban ticket view.

- Progress bar in each state to manage pending activities.
- The tags appear on the ticket with their corresponding color.
- State selection on each ticket.
- Image of the user assigned to the ticket.
- Color assignment using a color picker.

**Before**
![old_helpdesk](https://user-images.githubusercontent.com/48479898/64761812-3e82ed80-d53d-11e9-95aa-3cc860e194c4.png)

**After**
![new_helpdesk](https://user-images.githubusercontent.com/48479898/64761835-4e9acd00-d53d-11e9-87ab-3458933a1846.png)
