### PR TITLE
[FIX] Repeated active field failure in the helpdesk team view

### DIFF
--- a/helpdesk_mgmt/views/helpdesk_ticket_team_view.xml
+++ b/helpdesk_mgmt/views/helpdesk_ticket_team_view.xml
@@ -36,8 +36,7 @@
                         <field name="company_id" groups="base.group_multi_company"/>
                     </group>
                     <group>
-                        <group name="left">
-                            <field name="active" invisible="1"/>
+                        <group name="left"> 
                             <label for="alias_name" string="Email Alias"/>
                             <div class="oe_inline" name="alias_def">
                                 <field name="alias_id" class="oe_read_only oe_inline"


### PR DESCRIPTION
In the team view form active's smartbutton did not show the string because it was repeated in the view and showed the button wrong