### PR TITLE
#Issue 120 [12.0] "Assigned to" email notification sent to partner

### DIFF
--- a/helpdesk_mgmt/data/helpdesk_data.xml
+++ b/helpdesk_mgmt/data/helpdesk_data.xml
@@ -13,11 +13,10 @@
       <field name="name">Ticket Assignment</field>
       <field name="model_id" ref="model_helpdesk_ticket"/>
       <field name="email_from">${object.company_id.partner_id.email}</field>
-      <field name="email_cc">${not object.partner_id and object.partner_email or ''|safe},</field>
       <field name="subject">${object.company_id.name} Ticket Assignment (Ref ${object.number or 'n/a' })</field>
-      <field name="partner_to">${object.partner_id.id}</field>
+      <field name="email_to">${object.user_id.partner_id.email}</field>
       <field name="auto_delete" eval="False"/>
-      <field name="lang">${object.partner_id.lang}</field>
+      <field name="lang">${object.user_id.partner_id.lang}</field>
       <field name="body_html" type="xml">
         <p>Hello ${object.user_id.name},</p>
         <p>The ticket ${object.number} has been assigned to you.</p>

--- a/helpdesk_mgmt/views/helpdesk_ticket_team_view.xml
+++ b/helpdesk_mgmt/views/helpdesk_ticket_team_view.xml
@@ -36,8 +36,7 @@
                         <field name="company_id" groups="base.group_multi_company"/>
                     </group>
                     <group>
-                        <group name="left">
-                            <field name="active" invisible="1"/>
+                        <group name="left"> 
                             <label for="alias_name" string="Email Alias"/>
                             <div class="oe_inline" name="alias_def">
                                 <field name="alias_id" class="oe_read_only oe_inline"


### PR DESCRIPTION
Solved issue #120. 

When assigning the user a ticket, the email is reported to the user and not to the partner, selecting the user's language