### PR TITLE
[IMP] Relationship between Category and Team

### DIFF
--- a/helpdesk_mgmt/controllers/main.py
+++ b/helpdesk_mgmt/controllers/main.py
@@ -69,7 +69,7 @@ class HelpdeskTicketController(http.Controller):
                         {
                             "name": c_file.filename,
                             "datas": base64.b64encode(data),
-                            "datas_fname": c_file.filename,
+                            #"datas_fname": c_file.filename,
                             "res_model": "helpdesk.ticket",
                             "res_id": new_ticket.id,
                         }

--- a/helpdesk_mgmt/controllers/main.py
+++ b/helpdesk_mgmt/controllers/main.py
@@ -69,7 +69,6 @@ class HelpdeskTicketController(http.Controller):
                         {
                             "name": c_file.filename,
                             "datas": base64.b64encode(data),
-                            #"datas_fname": c_file.filename,
                             "res_model": "helpdesk.ticket",
                             "res_id": new_ticket.id,
                         }

--- a/helpdesk_mgmt/controllers/main.py
+++ b/helpdesk_mgmt/controllers/main.py
@@ -58,6 +58,10 @@ class HelpdeskTicketController(http.Controller):
             .sudo()
             .search([("name", "=", kw.get("name")), ("email", "=", kw.get("email"))])
             .id,
+            "team_id": request.env["helpdesk.ticket.category"]
+            .sudo()
+            .search([("id", "=", kw.get("category"))])
+            .team_id.id,
         }
         new_ticket = request.env["helpdesk.ticket"].sudo().create(vals)
         new_ticket.message_subscribe(partner_ids=request.env.user.partner_id.ids)

--- a/helpdesk_mgmt/controllers/myaccount.py
+++ b/helpdesk_mgmt/controllers/myaccount.py
@@ -113,10 +113,12 @@ class CustomerPortalHelpdesk(CustomerPortal):
         closed_stages = request.env["helpdesk.ticket.stage"].search(
             [("closed", "=", True)]
         )
+        file = request.env['ir.attachment'].search([('res_model','=','helpdesk.ticket'),('res_id','=',ticket.id)])
         values = {
             "page_name": "ticket",
             "ticket": ticket,
             "closed_stages": closed_stages,
+            "files": file,
         }
 
         if kwargs.get("error"):

--- a/helpdesk_mgmt/controllers/myaccount.py
+++ b/helpdesk_mgmt/controllers/myaccount.py
@@ -113,7 +113,11 @@ class CustomerPortalHelpdesk(CustomerPortal):
         closed_stages = request.env["helpdesk.ticket.stage"].search(
             [("closed", "=", True)]
         )
-        file = request.env['ir.attachment'].sudo().search([('res_model','=','helpdesk.ticket'),('res_id','=',ticket.id)])
+        file = (
+            request.env['ir.attachment']
+            .sudo()
+            .search([('res_model', '=', 'helpdesk.ticket'), ('res_id', '=', ticket.id)])
+        )
         values = {
             "page_name": "ticket",
             "ticket": ticket,

--- a/helpdesk_mgmt/controllers/myaccount.py
+++ b/helpdesk_mgmt/controllers/myaccount.py
@@ -114,9 +114,9 @@ class CustomerPortalHelpdesk(CustomerPortal):
             [("closed", "=", True)]
         )
         file = (
-            request.env['ir.attachment']
+            request.env["ir.attachment"]
             .sudo()
-            .search([('res_model', '=', 'helpdesk.ticket'), ('res_id', '=', ticket.id)])
+            .search([("res_model", "=", "helpdesk.ticket"), ("res_id", "=", ticket.id)])
         )
         values = {
             "page_name": "ticket",

--- a/helpdesk_mgmt/controllers/myaccount.py
+++ b/helpdesk_mgmt/controllers/myaccount.py
@@ -113,7 +113,7 @@ class CustomerPortalHelpdesk(CustomerPortal):
         closed_stages = request.env["helpdesk.ticket.stage"].search(
             [("closed", "=", True)]
         )
-        file = request.env['ir.attachment'].search([('res_model','=','helpdesk.ticket'),('res_id','=',ticket.id)])
+        file = request.env['ir.attachment'].sudo().search([('res_model','=','helpdesk.ticket'),('res_id','=',ticket.id)])
         values = {
             "page_name": "ticket",
             "ticket": ticket,

--- a/helpdesk_mgmt/data/helpdesk_data.xml
+++ b/helpdesk_mgmt/data/helpdesk_data.xml
@@ -15,7 +15,7 @@
             <field name="email_from">${object.company_id.partner_id.email}</field>
             <field
                 name="email_cc"
-            >${not object.partner_id and object.partner_email or ''|safe},</field>
+            >${not object.user_id.name and object.user_id.email or ''|safe},</field>
             <field
                 name="subject"
             >${object.company_id.name} Ticket Assignment (Ref ${object.number or 'n/a' })</field>

--- a/helpdesk_mgmt/data/helpdesk_data.xml
+++ b/helpdesk_mgmt/data/helpdesk_data.xml
@@ -15,7 +15,7 @@
             <field name="email_from">${object.company_id.partner_id.email}</field>
             <field
                 name="email_cc"
-            >${not object.user_id.name and object.user_id.email or ''|safe},</field>
+            >${not object.partner_id and object.partner_email or ''|safe},</field>
             <field
                 name="subject"
             >${object.company_id.name} Ticket Assignment (Ref ${object.number or 'n/a' })</field>

--- a/helpdesk_mgmt/models/helpdesk_ticket_category.py
+++ b/helpdesk_mgmt/models/helpdesk_ticket_category.py
@@ -13,3 +13,7 @@ class HelpdeskCategory(models.Model):
         string="Company",
         default=lambda self: self.env.company,
     )
+    team_id = fields.Many2one(
+        comodel_name="helpdesk.ticket.team",
+        string="Team"
+    )

--- a/helpdesk_mgmt/models/helpdesk_ticket_category.py
+++ b/helpdesk_mgmt/models/helpdesk_ticket_category.py
@@ -13,7 +13,4 @@ class HelpdeskCategory(models.Model):
         string="Company",
         default=lambda self: self.env.company,
     )
-    team_id = fields.Many2one(
-        comodel_name="helpdesk.ticket.team",
-        string="Team"
-    )
+    team_id = fields.Many2one(comodel_name="helpdesk.ticket.team", string="Team")

--- a/helpdesk_mgmt/views/helpdesk_ticket_category_views.xml
+++ b/helpdesk_mgmt/views/helpdesk_ticket_category_views.xml
@@ -44,6 +44,7 @@
                         </h1>
                     </div>
                     <group name="main">
+                        <field name="team_id" />
                         <field name="company_id" groups="base.group_multi_company" />
                     </group>
                 </sheet>
@@ -56,6 +57,7 @@
         <field name="arch" type="xml">
             <tree string="Team">
                 <field name="name" />
+                <field name="team_id" />
             </tree>
         </field>
     </record>

--- a/helpdesk_mgmt/views/helpdesk_ticket_templates.xml
+++ b/helpdesk_mgmt/views/helpdesk_ticket_templates.xml
@@ -180,9 +180,12 @@
                                     <strong>Last Stage Update:</strong>
                                     <span t-field="ticket.last_stage_update" />
                                     <br />
-                                    <strong>Attachments:</strong><br />
+                                    <strong>Attachments:</strong>
+                                    <br />
                                     <t t-foreach="files" t-as="f">
-                                        <a t-att-href="'/web/content/%i?download=true' % f.id">
+                                        <a 
+                                            t-att-href="'/web/content/%i?download=true' % f.id"
+                                        >
                                             <span class="fa fa-download" />
                                             <span t-esc="f.name" />
                                         </a>
@@ -197,7 +200,8 @@
                         <br />
                         <br />
                         <h4 class="page-header">Description</h4>
-                        <t t-raw="ticket.description" /><br />
+                        <t t-raw="ticket.description" />
+                        <br />
                         <br />
                         <h4 class="page-header">History</h4>
                         <!-- Options:Ticket Chatter: user can reply -->

--- a/helpdesk_mgmt/views/helpdesk_ticket_templates.xml
+++ b/helpdesk_mgmt/views/helpdesk_ticket_templates.xml
@@ -183,7 +183,7 @@
                                     <strong>Attachments:</strong>
                                     <br />
                                     <t t-foreach="files" t-as="f">
-                                        <a 
+                                        <a
                                             t-att-href="'/web/content/%i?download=true' % f.id"
                                         >
                                             <span class="fa fa-download" />

--- a/helpdesk_mgmt/views/helpdesk_ticket_templates.xml
+++ b/helpdesk_mgmt/views/helpdesk_ticket_templates.xml
@@ -122,6 +122,7 @@
             </div>
         </t>
     </template>
+    
     <template id="portal_helpdesk_ticket_page" name="Ticket Portal Template">
         <t t-call="portal.portal_layout">
             <div class="container">
@@ -179,14 +180,25 @@
                                     <strong>Last Stage Update:</strong>
                                     <span t-field="ticket.last_stage_update" />
                                     <br />
+                                    <strong>Attachments:</strong><br />
+                                    <t t-foreach="files" t-as="f">
+                                        <a t-att-href="'/web/content/%i?download=true' % f.id">
+                                            <span class="fa fa-download" />
+                                            <span t-esc="f.name" />
+                                        </a>
+                                        <br />
+                                    </t>
+                                    <br />
                                 </div>
                             </div>
                             <br />
                             <br />
-                            <h4 class="page-header">Description</h4>
-                            <t t-raw="ticket.description" />
-                            <br />
                         </div>
+                        <br />
+                        <br />
+                        <h4 class="page-header">Description</h4>
+                        <t t-raw="ticket.description" /><br />
+                        <br />
                         <h4 class="page-header">History</h4>
                         <!-- Options:Ticket Chatter: user can reply -->
                         <t t-call="portal.message_thread">

--- a/helpdesk_mgmt/views/helpdesk_ticket_templates.xml
+++ b/helpdesk_mgmt/views/helpdesk_ticket_templates.xml
@@ -122,7 +122,6 @@
             </div>
         </t>
     </template>
-    
     <template id="portal_helpdesk_ticket_page" name="Ticket Portal Template">
         <t t-call="portal.portal_layout">
             <div class="container">


### PR DESCRIPTION
A relationship between category and team is added. So when the user creates a ticket and selects the category, it relates it to the corresponding team and appears on the board.

![image](https://user-images.githubusercontent.com/62858972/84079614-3f07c200-a9b1-11ea-8de1-7d20998b4215.png)

![image](https://user-images.githubusercontent.com/62858972/84079635-45963980-a9b1-11ea-936c-335d20ffa5e8.png)


The team is assigned automatically