### PR TITLE
[FIX] helpdesk_mgmt: fix error when submitting a ticket with an attachment

### DIFF
--- a/helpdesk_mgmt/controllers/main.py
+++ b/helpdesk_mgmt/controllers/main.py
@@ -69,7 +69,6 @@ class HelpdeskTicketController(http.Controller):
                         {
                             "name": c_file.filename,
                             "datas": base64.b64encode(data),
-                            "datas_fname": c_file.filename,
                             "res_model": "helpdesk.ticket",
                             "res_id": new_ticket.id,
                         }


### PR DESCRIPTION
Fixes #138 which was caused by deprecated field datas_fname being included in the attachment values