### PR TITLE
[12.0][FIX] helpdesk_mgmt: Consistently fill partner fields on helpdesk tickets

### DIFF
--- a/helpdesk_mgmt/models/helpdesk_ticket.py
+++ b/helpdesk_mgmt/models/helpdesk_ticket.py
@@ -122,6 +122,14 @@ class HelpdeskTicket(models.Model):
                 seq = seq.with_context(force_company=vals['company_id'])
             vals['number'] = seq.next_by_code(
                 'helpdesk.ticket.sequence') or '/'
+
+        if vals.get("partner_id") and (
+            "partner_name" not in vals or "partner_email" not in vals
+        ):
+            partner = self.env["res.partner"].browse(vals["partner_id"])
+            vals.setdefault("partner_name", partner.name)
+            vals.setdefault("partner_email", partner.email)
+
         res = super().create(vals)
 
         # Check if mail to the user has to be sent

--- a/helpdesk_mgmt/tests/test_helpdesk_ticket.py
+++ b/helpdesk_mgmt/tests/test_helpdesk_ticket.py
@@ -67,3 +67,28 @@ class TestHelpdeskTicket(common.SavepointCase):
             old_ticket_number != copy_ticket_number,
             'Helpdesk Ticket: A new ticket can not '
             'have the same number than the origin ticket.')
+
+    def test_helpdesk_ticket_create(self):
+        partner = self.env.ref("base.main_partner")
+
+        auto_named = self.env["helpdesk.ticket"].create(
+            {
+                "name": "Some name",
+                "description": "Some description",
+                "partner_id": partner.id,
+            }
+        )
+        self.assertEqual(auto_named.partner_name, partner.name)
+        self.assertEqual(auto_named.partner_email, partner.email)
+
+        manual_named = self.env["helpdesk.ticket"].create(
+            {
+                "name": "Some name",
+                "description": "Some description",
+                "partner_id": partner.id,
+                "partner_name": "Special name",
+                "partner_email": "special@example.org",
+            }
+        )
+        self.assertEqual(manual_named.partner_name, "Special name")
+        self.assertEqual(manual_named.partner_email, "special@example.org")


### PR DESCRIPTION
The `onchange` method fills in `partner_name` and `partner_email` in the web form, but it doesn't trigger on a bare call to `.create()`, e.g. from `fetchmail.server`.