### PR TITLE
[12.0][FIX] helpdesk_mgmt_project: missing context for task creation

### DIFF
--- a/helpdesk_mgmt_project/views/helpdesk_ticket_view.xml
+++ b/helpdesk_mgmt_project/views/helpdesk_ticket_view.xml
@@ -38,7 +38,8 @@
             <xpath expr="//field[@name='partner_email']" position="after">
                 <field name="project_id"/>
                 <field name="task_id" domain="[('project_id', '=', project_id)]"
-                               attrs="{'invisible':[('project_id', '=', False)]}"/>
+                               attrs="{'invisible':[('project_id', '=', False)]}"
+							   context="{'default_project_id': project_id}"/>
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
When creating a task within a ticket, selected project is not filled and task is created unlinked to project. This PR fixes it