### PR TITLE
[FIX] Helpdesk Management Timesheet

### DIFF
--- a/helpdesk_mgmt_timesheet/models/hr_timesheet.py
+++ b/helpdesk_mgmt_timesheet/models/hr_timesheet.py
@@ -25,5 +25,7 @@ class AccountAnalyticLine(models.Model):
     @api.onchange("ticket_id")
     def onchange_ticket_id(self):
         for record in self:
+            if not record.ticket_id:
+                continue
             record.project_id = record.ticket_id.project_id
             record.task_id = record.ticket_id.task_id


### PR DESCRIPTION
Before this commit, in any view with ticket_id present but unused the onchange would be called and set project and task to False. It was found while trying to integrate project_timesheet_time_control with helpdesk_mgmt_timesheet, where this onchange overrides the results of default_get.

After this commit, if a helpdesk ticket is not present when calling onchange, project and task ids are not reset to False.