### PR TITLE
[13.0][IMP] Make changing ticket type less annoying

### DIFF
--- a/helpdesk_type/models/helpdesk_ticket.py
+++ b/helpdesk_type/models/helpdesk_ticket.py
@@ -11,5 +11,7 @@ class HelpdeskTicket(models.Model):
 
     @api.onchange("type_id")
     def _onchange_type_id(self):
-        self.team_id = False
-        self.user_id = False
+        valid_team_ids = self.type_id.team_ids
+        if self.type_id and self.team_id not in valid_team_ids:
+            self.team_id = len(valid_team_ids) == 1 and valid_team_ids
+            self.user_id = False


### PR DESCRIPTION
Before this commit changing ticket type on a helpdesk ticket would
indiscriminately set the team and user to NULL. This was very annoying
especially for tickets received via email as it would wipe preset
fields.

After this commit, team and user is only set to NULL if it isn't a
valid team for the ticket type. If there is only 1 valid team the
helpdesk team is changed to that.