### PR TITLE
parameter `values` for `check` method may be None and when it is, it …

### DIFF
--- a/helpdesk_mgmt/models/ir_attachment.py
+++ b/helpdesk_mgmt/models/ir_attachment.py
@@ -8,7 +8,8 @@ class Attachment(models.Model):
     def check(self, mode, values=None):
         group_portal = self.env.ref('base.group_portal')
         if (
-            mode == 'write' and values.get('res_model') == 'helpdesk.ticket' and
+            values and mode == 'write' and
+            values.get('res_model') == 'helpdesk.ticket' and
             group_portal.id in self.env.user.groups_id.ids
         ):
             # when portal user is writing a file attached to a ticket,


### PR DESCRIPTION
…will crash