### PR TITLE
[12.0][IMP] helpdesk_mgmt: search tickets from both number and name

### DIFF
--- a/helpdesk_mgmt/views/helpdesk_ticket_view.xml
+++ b/helpdesk_mgmt/views/helpdesk_ticket_view.xml
@@ -15,7 +15,7 @@
         <field name="model">helpdesk.ticket</field>
         <field name="arch" type="xml">
             <search>
-                <field name="number"/>
+                <field string="Ticket" name="number" filter_domain="['|',('number', 'ilike', self),('name', 'ilike', self)]"/>
                 <field name="partner_id"/>
                 <field name="user_id"/>
                 <field name="name"/>


### PR DESCRIPTION
With this improvement, default search for tickets will look into both number and name (title) ticket fields, which may be useful IMO.