### PR TITLE
[12.0][FIX] fixed xml id in fsm_location.py

### DIFF
--- a/helpdesk_mgmt_fieldservice/models/fsm_location.py
+++ b/helpdesk_mgmt_fieldservice/models/fsm_location.py
@@ -29,7 +29,7 @@ class FSMLocation(models.Model):
             action['context'] = {}
             if len(ticket_ids) == 1:
                 action['views'] = [(
-                    self.env.ref('helpdesk.helpdesk_ticket_view_form').id,
+                    self.env.ref('helpdesk_mgmt.ticket_view_form').id,
                     'form')]
                 action['res_id'] = ticket_ids.ids[0]
             else:


### PR DESCRIPTION
The previous xml id doesn't seem to exist, and raises an error when the method is called.