### PR TITLE
[helpdesk_type][fix] only reset team and user when the new type does not match

### DIFF
--- a/helpdesk_type/models/helpdesk_ticket.py
+++ b/helpdesk_type/models/helpdesk_ticket.py
@@ -11,5 +11,6 @@ class HelpdeskTicket(models.Model):
 
     @api.onchange("type_id")
     def _onchange_type_id(self):
-        self.team_id = False
-        self.user_id = False
+        if self.type_id and self.team_id and self.type_id not in self.team_id.type_ids:
+            self.team_id = False
+            self.user_id = False


### PR DESCRIPTION
Otherwise the team is being set to blank when you create a new ticket from the dasbhoard.

cc @NuriaMForgeFlow @LoisRForgeFlow @AaronHForgeFlow 