### PR TITLE
[13.0][FIX]helpdesk_mgmt_timesheet: default_project not a field helpdesk.ticket.team

### DIFF
--- a/helpdesk_mgmt_timesheet/models/helpdesk_ticket_team.py
+++ b/helpdesk_mgmt_timesheet/models/helpdesk_ticket_team.py
@@ -15,4 +15,4 @@ class HelpdeskTicketTeam(models.Model):
     @api.constrains("allow_timesheet")
     def _constrains_allow_timesheet(self):
         if not self.allow_timesheet:
-            self.default_project = False
+            self.default_project_id = False


### PR DESCRIPTION
default_project has to be replaced by default_project_id which is the right name of the field