### PR TITLE
[IMP][12.0] Improved all_orders_closed calculation

### DIFF
--- a/helpdesk_mgmt_fieldservice/__init__.py
+++ b/helpdesk_mgmt_fieldservice/__init__.py
@@ -1,2 +1,3 @@
 from . import models
+from . import tests
 from . import wizards

--- a/helpdesk_mgmt_fieldservice/__manifest__.py
+++ b/helpdesk_mgmt_fieldservice/__manifest__.py
@@ -5,10 +5,11 @@
     'name': 'Helpdesk Mgmt Fieldservice',
     'summary': """
         Create service requests from a ticket""",
-    'version': '12.0.1.1.0',
+    'version': '12.0.1.2.0',
     'license': 'LGPL-3',
     "author": "Open Source Integrators, "
               "Escodoo, "
+              "PyTech SRL, "
               "Odoo Community Association (OCA)",
     'website': 'https://github.com/OCA/helpdesk',
     'depends': [

--- a/helpdesk_mgmt_fieldservice/migrations/12.0.1.2.0/post-migrate.py
+++ b/helpdesk_mgmt_fieldservice/migrations/12.0.1.2.0/post-migrate.py
@@ -1,0 +1,7 @@
+from odoo import api, SUPERUSER_ID
+
+
+def migrate(cr, version):
+    """Recalculate all_orders_closed after fix"""
+    env = api.Environment(cr, SUPERUSER_ID, {"active_test": False})
+    env["helpdesk.ticket"].search([])._compute_all_closed()

--- a/helpdesk_mgmt_fieldservice/tests/__init__.py
+++ b/helpdesk_mgmt_fieldservice/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_helpdesk_ticket

--- a/helpdesk_mgmt_fieldservice/tests/test_helpdesk_ticket.py
+++ b/helpdesk_mgmt_fieldservice/tests/test_helpdesk_ticket.py
@@ -1,0 +1,66 @@
+from odoo.tests import common
+
+
+class TestHelpdeskTicket(common.SavepointCase):
+    @classmethod
+    def setUpClass(cls):
+        super(TestHelpdeskTicket, cls).setUpClass()
+        cls.HelpdeskTicket = cls.env["helpdesk.ticket"]
+        cls.FsmOrder = cls.env["fsm.order"]
+        cls.fsm_location = cls.env.ref("fieldservice.test_location")
+        cls.ticket = cls.HelpdeskTicket.create(
+            {
+                "name": "Test 1",
+                "description": "Ticket test",
+            }
+        )
+
+    def test_helpdesk_ticket_all_orders_closed(self):
+        self.assertFalse(
+            self.ticket.all_orders_closed,
+            "Helpdesk Ticket: with no linked FSM Order, "
+            "all_orders_closed should be False",
+        )
+
+        order = self.FsmOrder.create(
+            {
+                "location_id": self.fsm_location.id,
+                "ticket_id": self.ticket.id,
+            }
+        )
+
+        self.assertFalse(
+            order.stage_id.is_closed, "FSM Order: should be open by default"
+        )
+        self.assertFalse(
+            self.ticket.all_orders_closed,
+            "Helpdesk Ticket: with one FSM Order open, "
+            "all_orders_closed should be False",
+        )
+
+        order.action_complete()
+        self.assertTrue(order.stage_id.is_closed, "FSM Order: should be closed")
+        self.assertTrue(
+            self.ticket.all_orders_closed,
+            "Helpdesk Ticket: with one FSM Order closed, "
+            "all_orders_closed should be True",
+        )
+
+        order2 = self.FsmOrder.create(
+            {
+                "location_id": self.fsm_location.id,
+                "ticket_id": self.ticket.id,
+            }
+        )
+        self.assertFalse(
+            self.ticket.all_orders_closed,
+            "Helpdesk Ticket: with one FSM Order open and one closed, "
+            "all_orders_closed should be False",
+        )
+
+        order2.stage_id.is_closed = True
+        self.assertTrue(
+            self.ticket.all_orders_closed,
+            "Helpdesk Ticket: changing the attribute is_closed on the second order's "
+            "stage, all_orders_closed should be recalculated to True",
+        )


### PR DESCRIPTION
Previously the method would check if the stage name was "closed" or "cancelled" but this is highly unreliable as the user can edit the names, or add more stages that are to be considered closed stages.

It is much better and more reliable to check the boolean field is_closed on the stage itself, rather than some arbitrary names.