### PR TITLE
[FIX] 13.0 Helpdesk Management Dashboard Performance

### DIFF
--- a/helpdesk_mgmt/views/helpdesk_dashboard_views.xml
+++ b/helpdesk_mgmt/views/helpdesk_dashboard_views.xml
@@ -7,7 +7,6 @@
             <kanban class="oe_background_grey o_kanban_dashboard" create="0">
                 <field name="name" />
                 <field name="color" />
-                <field name="todo_ticket_ids" />
                 <field name="todo_ticket_count" />
                 <field name="todo_ticket_count_unassigned" />
                 <field name="todo_ticket_count_unattended" />


### PR DESCRIPTION
Removes the useless related field todo_ticket_ids.

Before this commit dashboard view progressively slowed until unloadable.
After this commit - instant with 50,000 tickets.

Note the field todo_ticket_ids wasn't actually used anywhere except in computing some values and being inexplicably loaded in dashboard.