### PR TITLE
[12.0][FIX] helpdesk_mgmt: Preserve search parameters in the portal ticket pagination

### DIFF
--- a/helpdesk_mgmt/controllers/myaccount.py
+++ b/helpdesk_mgmt/controllers/myaccount.py
@@ -129,7 +129,7 @@ class CustomerPortal(CustomerPortal):
         # pager
         pager = portal_pager(
             url="/my/tickets",
-            url_args={},
+            url_args={"sortby": sortby, "filterby": filterby},
             total=ticket_count,
             page=page,
             step=self._items_per_page


### PR DESCRIPTION
Without this change sorting and filtering is reset when you navigate to another page.