### PR TITLE
[12.0] [FIX] Fixed permission error on res_partner

### DIFF
--- a/helpdesk_mgmt_fieldservice/views/res_partner.xml
+++ b/helpdesk_mgmt_fieldservice/views/res_partner.xml
@@ -3,6 +3,7 @@
     <record id="res_partner_form_ticket_context" model="ir.ui.view">
         <field name="name">res.partner.form.ticket.context</field>
         <field name="model">res.partner</field>
+        <field name="groups_id" eval="[(4, ref('fieldservice.group_fsm_user_own'))]"/>
         <field name="inherit_id" ref="base.view_partner_form"/>
         <field name="arch" type="xml">
             <button name="action_view_helpdesk_tickets" position="attributes">


### PR DESCRIPTION
When trying to open a res_partner form with a user who doesn't have permission to read fieldservice data, this view causes an error because it tries to set attributes to a button that doesn't exist. Specifying groups_id fixes this, extending the view only if the current user has permissions to see that button.