### PR TITLE
[FIX][12.0] portal user can comment on tickets they can read

### DIFF
--- a/helpdesk_mgmt/models/helpdesk_ticket.py
+++ b/helpdesk_mgmt/models/helpdesk_ticket.py
@@ -8,6 +8,7 @@ class HelpdeskTicket(models.Model):
     _description = 'Helpdesk Ticket'
     _rec_name = 'number'
     _order = 'priority desc, sequence, number desc'
+    _mail_post_access = "read"
     _inherit = ['mail.thread', 'mail.activity.mixin', 'portal.mixin']
 
     def _get_default_stage_id(self):


### PR DESCRIPTION
Portal users cannot comment on their tickets, as they don't have write permissions on the ticket model. This PR lets them add comments without otherwise altering permissions.

Porting of #139 from 13.0 to 12.0. 
See issue #137