### PR TITLE
[14.0][FIX] helpdesk_mgmt: remove wrong call

### DIFF
--- a/helpdesk_mgmt/models/helpdesk_ticket.py
+++ b/helpdesk_mgmt/models/helpdesk_ticket.py
@@ -69,10 +69,10 @@ class HelpdeskTicket(models.Model):
     )
     priority = fields.Selection(
         selection=[
-            ("0", _("Low")),
-            ("1", _("Medium")),
-            ("2", _("High")),
-            ("3", _("Very High")),
+            ("0", "Low"),
+            ("1", "Medium"),
+            ("2", "High"),
+            ("3", "Very High"),
         ],
         string="Priority",
         default="1",


### PR DESCRIPTION
In the context of this call, the user's language is not known and therefore the call is unnecessary and incorrect.

@Tecnativa