### PR TITLE
helpdesk_mgmt: fixed a rights issue with accessing the helpdesk.ticket.team page

### DIFF
--- a/helpdesk_mgmt/models/helpdesk_ticket.py
+++ b/helpdesk_mgmt/models/helpdesk_ticket.py
@@ -45,7 +45,7 @@ class HelpdeskTicket(models.Model):
     assigned_date = fields.Datetime(string="Assigned Date")
     closed_date = fields.Datetime(string="Closed Date")
     closed = fields.Boolean(related="stage_id.closed")
-    unattended = fields.Boolean(related="stage_id.unattended")
+    unattended = fields.Boolean(related="stage_id.unattended", store=True)
     tag_ids = fields.Many2many(comodel_name="helpdesk.ticket.tag", string="Tags")
     company_id = fields.Many2one(
         comodel_name="res.company",

--- a/helpdesk_mgmt/models/helpdesk_ticket_team.py
+++ b/helpdesk_mgmt/models/helpdesk_ticket_team.py
@@ -40,12 +40,7 @@ class HelpdeskTeam(models.Model):
         inverse_name="team_id",
         string="Tickets",
     )
-    todo_ticket_ids = fields.One2many(
-        related="ticket_ids",
-        domain="[('closed', '=', False)]",
-        string="Todo tickets",
-        readonly=True,
-    )
+
     todo_ticket_count = fields.Integer(
         string="Number of tickets", compute="_compute_todo_tickets"
     )
@@ -62,18 +57,18 @@ class HelpdeskTeam(models.Model):
     @api.depends("ticket_ids", "ticket_ids.stage_id")
     def _compute_todo_tickets(self):
         for record in self:
-            record.todo_ticket_ids = record.ticket_ids.filtered(
-                lambda ticket: not ticket.closed
+            todo_ticket_ids = self.env["helpdesk.ticket"].search(
+                [("team_id", "=", record.id), ("closed", "=", False)]
             )
-            record.todo_ticket_count = len(record.todo_ticket_ids)
+            record.todo_ticket_count = len(todo_ticket_ids)
             record.todo_ticket_count_unassigned = len(
-                record.todo_ticket_ids.filtered(lambda ticket: not ticket.user_id)
+                todo_ticket_ids.filtered(lambda ticket: not ticket.user_id)
             )
             record.todo_ticket_count_unattended = len(
-                record.todo_ticket_ids.filtered(lambda ticket: ticket.unattended)
+                todo_ticket_ids.filtered(lambda ticket: ticket.unattended)
             )
             record.todo_ticket_count_high_priority = len(
-                record.todo_ticket_ids.filtered(lambda ticket: ticket.priority == "3")
+                todo_ticket_ids.filtered(lambda ticket: ticket.priority == "3")
             )
 
     def _alias_get_creation_values(self):

--- a/helpdesk_mgmt/models/helpdesk_ticket_team.py
+++ b/helpdesk_mgmt/models/helpdesk_ticket_team.py
@@ -56,19 +56,33 @@ class HelpdeskTeam(models.Model):
 
     @api.depends("ticket_ids", "ticket_ids.stage_id")
     def _compute_todo_tickets(self):
-        for record in self:
-            todo_ticket_ids = self.env["helpdesk.ticket"].search(
-                [("team_id", "=", record.id), ("closed", "=", False)]
+        ticket_model = self.env["helpdesk.ticket"]
+        fetch_data = ticket_model.read_group(
+            [("team_id", "in", self.ids), ("closed", "=", False)],
+            ["team_id", "user_id", "unattended", "priority"],
+            ["team_id", "user_id", "unattended", "priority"],
+            lazy=False,
+        )
+        result = [
+            [
+                data["team_id"][0],
+                data["user_id"] and data["user_id"][0],
+                data["unattended"],
+                data["priority"],
+                data["__count"],
+            ]
+            for data in fetch_data
+        ]
+        for team in self:
+            team.todo_ticket_count = sum([r[4] for r in result if r[0] == team.id])
+            team.todo_ticket_count_unassigned = sum(
+                [r[4] for r in result if r[0] == team.id and not r[1]]
             )
-            record.todo_ticket_count = len(todo_ticket_ids)
-            record.todo_ticket_count_unassigned = len(
-                todo_ticket_ids.filtered(lambda ticket: not ticket.user_id)
+            team.todo_ticket_count_unattended = sum(
+                [r[4] for r in result if r[0] == team.id and r[2]]
             )
-            record.todo_ticket_count_unattended = len(
-                todo_ticket_ids.filtered(lambda ticket: ticket.unattended)
-            )
-            record.todo_ticket_count_high_priority = len(
-                todo_ticket_ids.filtered(lambda ticket: ticket.priority == "3")
+            team.todo_ticket_count_high_priority = sum(
+                [r[4] for r in result if r[0] == team.id and r[3] == "3"]
             )
 
     def _alias_get_creation_values(self):

--- a/helpdesk_mgmt/views/helpdesk_dashboard_views.xml
+++ b/helpdesk_mgmt/views/helpdesk_dashboard_views.xml
@@ -7,7 +7,6 @@
             <kanban class="oe_background_grey o_kanban_dashboard" create="0">
                 <field name="name" />
                 <field name="color" />
-                <field name="todo_ticket_ids" />
                 <field name="todo_ticket_count" />
                 <field name="todo_ticket_count_unassigned" />
                 <field name="todo_ticket_count_unattended" />

--- a/helpdesk_mgmt/views/helpdesk_ticket_team_views.xml
+++ b/helpdesk_mgmt/views/helpdesk_ticket_team_views.xml
@@ -148,6 +148,20 @@
         <field name="arch" type="xml">
             <tree string="Team">
                 <field name="name" />
+                <field name="category_ids" widget="many2many_tags" />
+                <field name="todo_ticket_count" string="Active tickets" />
+                <field
+                    name="todo_ticket_count_unassigned"
+                    string="Unassigned tickets"
+                />
+                <field
+                    name="todo_ticket_count_unattended"
+                    string="Unattended tickets"
+                />
+                <field
+                    name="todo_ticket_count_high_priority"
+                    string="Priority tickets"
+                />
             </tree>
         </field>
     </record>


### PR DESCRIPTION
fixed an issue where users with the helpdesk groups "user" and "user: personal tickets" werent able to see the helpdesk.ticket.team page as it tried to do a write to a record with the users rights, which they of course do not have the right to do.