### PR TITLE
[14.0][IMP] helpdesk_mgmt: allow to define default team for a category

### DIFF
--- a/helpdesk_mgmt/models/helpdesk_ticket.py
+++ b/helpdesk_mgmt/models/helpdesk_ticket.py
@@ -129,6 +129,8 @@ class HelpdeskTicket(models.Model):
     def create(self, vals):
         if vals.get("number", "/") == "/":
             vals["number"] = self._prepare_ticket_number(vals)
+        if not vals.get("team_id") and vals.get("category_id"):
+            vals["team_id"] = self._prepare_team_id(vals)
         return super().create(vals)
 
     def copy(self, default=None):
@@ -166,6 +168,11 @@ class HelpdeskTicket(models.Model):
         super()._compute_access_url()
         for item in self:
             item.access_url = "/my/ticket/%s" % (item.id)
+
+    def _prepare_team_id(self, values):
+        category = self.env["helpdesk.ticket.category"].browse(values["category_id"])
+        if category.default_team_id:
+            return category.default_team_id.id
 
     # ---------------------------------------------------
     # Mail gateway

--- a/helpdesk_mgmt/models/helpdesk_ticket_category.py
+++ b/helpdesk_mgmt/models/helpdesk_ticket_category.py
@@ -20,3 +20,7 @@ class HelpdeskCategory(models.Model):
         string="Company",
         default=lambda self: self.env.company,
     )
+    default_team_id = fields.Many2one(
+        comodel_name="helpdesk.ticket.team",
+        string="Default team",
+    )

--- a/helpdesk_mgmt/tests/test_helpdesk_ticket_team.py
+++ b/helpdesk_mgmt/tests/test_helpdesk_ticket_team.py
@@ -78,3 +78,33 @@ class TestHelpdeskTicketTeam(common.SavepointCase):
             1,
             "Helpdesk Ticket: Helpdesk ticket team should " "have one ticket to do.",
         )
+
+    def test_helpdesk_ticket_team_from_category(self):
+        self.assertEqual(
+            self.team_id.todo_ticket_count,
+            2,
+        )
+        category = self.env.ref("helpdesk_mgmt.helpdesk_category_1")
+        self.env["helpdesk.ticket"].create(
+            {
+                "name": "Ticket 1",
+                "description": "Description",
+                "category_id": category.id,
+            }
+        )
+        self.assertEqual(
+            self.team_id.todo_ticket_count,
+            2,
+        )
+        category.default_team_id = self.team_id
+        self.env["helpdesk.ticket"].create(
+            {
+                "name": "Ticket 1",
+                "description": "Description",
+                "category_id": category.id,
+            }
+        )
+        self.assertEqual(
+            self.team_id.todo_ticket_count,
+            3,
+        )

--- a/helpdesk_mgmt/views/helpdesk_ticket_category_views.xml
+++ b/helpdesk_mgmt/views/helpdesk_ticket_category_views.xml
@@ -44,6 +44,7 @@
                         </h1>
                     </div>
                     <group name="main">
+                        <field name="default_team_id" />
                         <field name="company_id" groups="base.group_multi_company" />
                     </group>
                 </sheet>


### PR DESCRIPTION
On creation, if category if defined but not the team, the team will be deducted from the category's `default_team_id`