### PR TITLE
[13.0][FIX+IMP] helpdesk_mgmt: Use standard user assignation

### DIFF
--- a/helpdesk_mgmt/data/helpdesk_data.xml
+++ b/helpdesk_mgmt/data/helpdesk_data.xml
@@ -9,24 +9,6 @@
     </data>
     <data noupdate="1">
         <!--Email template -->
-        <record id="assignment_email_template" model="mail.template">
-            <field name="name">Ticket Assignment</field>
-            <field name="model_id" ref="model_helpdesk_ticket" />
-            <field name="email_from">${object.company_id.partner_id.email}</field>
-            <field
-                name="email_cc"
-            >${not object.partner_id and object.partner_email or ''|safe},</field>
-            <field
-                name="subject"
-            >${object.company_id.name} Ticket Assignment (Ref ${object.number or 'n/a' })</field>
-            <field name="partner_to">${object.partner_id.id}</field>
-            <field name="auto_delete" eval="False" />
-            <field name="lang">${object.partner_id.lang}</field>
-            <field name="body_html" type="xml">
-                <p>Hello ${object.user_id.name},</p>
-                <p>The ticket ${object.number} has been assigned to you.</p>
-            </field>
-        </record>
         <record id="closed_ticket_template" model="mail.template">
             <field name="name">Helpdesk Closed Ticket Notification Email</field>
             <field name="model_id" ref="helpdesk_mgmt.model_helpdesk_ticket" />

--- a/helpdesk_mgmt/models/helpdesk_ticket.py
+++ b/helpdesk_mgmt/models/helpdesk_ticket.py
@@ -21,7 +21,9 @@ class HelpdeskTicket(models.Model):
     number = fields.Char(string="Ticket number", default="/", readonly=True)
     name = fields.Char(string="Title", required=True)
     description = fields.Html(required=True, sanitize_style=True)
-    user_id = fields.Many2one(comodel_name="res.users", string="Assigned user")
+    user_id = fields.Many2one(
+        comodel_name="res.users", string="Assigned user", tracking=True, index=True
+    )
     user_ids = fields.Many2many(
         comodel_name="res.users", related="team_id.user_ids", string="Users"
     )
@@ -90,9 +92,6 @@ class HelpdeskTicket(models.Model):
     )
     active = fields.Boolean(default=True)
 
-    def send_user_mail(self):
-        self.env.ref("helpdesk_mgmt.assignment_email_template").send_mail(self.id)
-
     def assign_to_me(self):
         self.write({"user_id": self.env.user.id})
 
@@ -120,12 +119,7 @@ class HelpdeskTicket(models.Model):
     def create(self, vals):
         if vals.get("number", "/") == "/":
             vals["number"] = self._prepare_ticket_number(vals)
-        res = super().create(vals)
-
-        # Check if mail to the user has to be sent
-        if vals.get("user_id") and res:
-            res.send_user_mail()
-        return res
+        return super().create(vals)
 
     def copy(self, default=None):
         self.ensure_one()
@@ -146,14 +140,7 @@ class HelpdeskTicket(models.Model):
                     vals["closed_date"] = now
             if vals.get("user_id"):
                 vals["assigned_date"] = now
-
-        res = super().write(vals)
-
-        # Check if mail to the user has to be sent
-        for ticket in self:
-            if vals.get("user_id"):
-                ticket.send_user_mail()
-        return res
+        return super().write(vals)
 
     def action_duplicate_tickets(self):
         for ticket in self.browse(self.env.context["active_ids"]):


### PR DESCRIPTION
Odoo already includes a mechanism for notifying users when a document has been assigned to them, through the convention of the field name (`user_id`) and `tracking=True`.

Having to perform this manually is a lot of code to maintain, but it's also right now incorrect, as the notification is being sent also to the customer.

We switch here to the standard system.

An index is also good over this field that is widely used.

TT36502