### PR TITLE
[13.0][IMP] helpdesk_mgmt_rating: Only managers can change rating status

### DIFF
--- a/helpdesk_mgmt_rating/views/helpdesk_ticket_views.xml
+++ b/helpdesk_mgmt_rating/views/helpdesk_ticket_views.xml
@@ -34,6 +34,7 @@
         <field name="arch" type="xml">
             <xpath expr="//div[hasclass('oe_title')]" position="before">
                 <field name="positive_rate_percentage" invisible="1" />
+                <field name="rating_status" invisible="1" />
             </xpath>
             <div name="button_box" position="inside">
                 <button
@@ -46,6 +47,17 @@
                     <field name="rating_count" widget="statinfo" string="Ratings" />
                 </button>
             </div>
+        </field>
+    </record>
+    <record id="ticket_view_form_rating_status" model="ir.ui.view">
+        <field name="name">ticket.view.form: Rating status</field>
+        <field name="model">helpdesk.ticket</field>
+        <field name="inherit_id" ref="helpdesk_mgmt.ticket_view_form" />
+        <field
+            name="groups_id"
+            eval="[(4, ref('helpdesk_mgmt.group_helpdesk_manager'))]"
+        />
+        <field name="arch" type="xml">
             <xpath expr="//group[@name='main']/group[2]" position="after">
                 <group>
                     <field name="rating_status" widget="radio" />


### PR DESCRIPTION
Allowing any helpdesk user to change the rating status (to be rated or not) may lead to bad manipulations by these users, so we protect the field to only be changed by helpdesk managers.

@Tecnativa TT33737