### PR TITLE
[12.0][FIX] Removed hardcoded partner email on ticket creation

### DIFF
--- a/helpdesk_mgmt/__manifest__.py
+++ b/helpdesk_mgmt/__manifest__.py
@@ -4,7 +4,7 @@
     'name': 'Helpdesk Management',
     'summary': """
         Helpdesk""",
-    'version': '12.0.1.26.0',
+    'version': '12.0.1.27.0',
     'license': 'AGPL-3',
     'category': 'After-Sales',
     'author': 'AdaptiveCity, '

--- a/helpdesk_mgmt/data/helpdesk_data.xml
+++ b/helpdesk_mgmt/data/helpdesk_data.xml
@@ -193,6 +193,7 @@
       <field name="name">New</field>
       <field name="unattended">True</field>
       <field name="closed">False</field>
+      <field name="mail_template_id" ref="helpdesk_mgmt.created_ticket_template"/>
       <field name="company_id"/>
     </record>
     <record id="helpdesk_ticket_stage_in_progress" model="helpdesk.ticket.stage">

--- a/helpdesk_mgmt/migrations/12.0.1.27.0/post-migrate.py
+++ b/helpdesk_mgmt/migrations/12.0.1.27.0/post-migrate.py
@@ -1,0 +1,13 @@
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    new_stage = env.ref(
+        "helpdesk_mgmt.helpdesk_ticket_stage_new", raise_if_not_found=False
+    )
+    if new_stage and not new_stage.mail_template_id:
+        new_stage.mail_template_id = env.ref(
+            "helpdesk_mgmt.created_ticket_template", raise_if_not_found=False
+        )

--- a/helpdesk_mgmt/models/helpdesk_ticket.py
+++ b/helpdesk_mgmt/models/helpdesk_ticket.py
@@ -110,14 +110,6 @@ class HelpdeskTicket(models.Model):
             access_rights_uid=name_get_uid)
         return self.browse(ticket_ids).name_get()
 
-    def send_user_mail(self):
-        self.env.ref('helpdesk_mgmt.assignment_email_template'). \
-            send_mail(self.id, force_send=True)
-
-    def send_partner_mail(self):
-        self.env.ref('helpdesk_mgmt.created_ticket_template'). \
-            send_mail(self.id, force_send=True)
-
     def assign_to_me(self):
         self.write({'user_id': self.env.user.id})
 
@@ -196,11 +188,8 @@ class HelpdeskTicket(models.Model):
 
         res = super().create(vals)
 
-        # Check if mail to the user has to be sent
-        if (vals.get('partner_id') or vals.get('partner_email')) and res:
-            res.send_partner_mail()
-            if res.partner_id:
-                res.message_subscribe(partner_ids=res.partner_id.ids)
+        if res.partner_id:
+            res.message_subscribe(partner_ids=res.partner_id.ids)
         return res
 
     @api.multi


### PR DESCRIPTION
Should not hardcode email sending and email template on ticket creation. The method has been removed.

I've also removed the other hardcoded method that seems to have been left over from https://github.com/OCA/helpdesk/commit/8ffd5dccda40e9534b7142099c7878b105b86761

Migration is extra safe in case the stage has been removed or another email template has been set on the stage.

Ref #296 

