### PR TITLE
[13.0][IMP] helpdesk_mgmt: add full ticket name to customer view

### DIFF
--- a/helpdesk_mgmt/data/helpdesk_data.xml
+++ b/helpdesk_mgmt/data/helpdesk_data.xml
@@ -46,7 +46,7 @@
                             <tbody>
                               <td valign="top" style="font-family:Arial,Helvetica,sans-serif; color: #555; font-size: 14px;">
                                 <p>Hello ${object.partner_id.name or ''},</p>
-                                <p>The ticket ${object.number} has been closed.</p>
+                                <p>The ticket "${object.display_name}" has been closed.</p>
                               </td>
                             </tbody>
                           </table>
@@ -113,7 +113,7 @@
                             <tbody>
                               <td valign="top" style="font-family:Arial,Helvetica,sans-serif; color: #555; font-size: 14px;">
                                 <p>Hello ${object.user_id.name},</p>
-                                <p>The ticket ${object.number} stage has changed to ${object.stage_id.name}.</p>
+                                <p>The ticket "${object.display_name}" stage has changed to ${object.stage_id.name}.</p>
                               </td>
                             </tbody>
                           </table>

--- a/helpdesk_mgmt/migrations/13.0.1.7.0/pre-migrate.py
+++ b/helpdesk_mgmt/migrations/13.0.1.7.0/pre-migrate.py
@@ -1,0 +1,11 @@
+# Copyright 2022 ForgeFlow S.L. (https://www.forgeflow.com)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    openupgrade.delete_record_translations(
+        env.cr, "helpdesk_mgmt", ["closed_ticket_template", "changed_stage_template"]
+    )

--- a/helpdesk_mgmt/models/helpdesk_ticket.py
+++ b/helpdesk_mgmt/models/helpdesk_ticket.py
@@ -92,6 +92,12 @@ class HelpdeskTicket(models.Model):
     )
     active = fields.Boolean(default=True)
 
+    def name_get(self):
+        res = []
+        for rec in self:
+            res.append((rec.id, rec.number + " - " + rec.name))
+        return res
+
     def assign_to_me(self):
         self.write({"user_id": self.env.user.id})
 

--- a/helpdesk_mgmt/views/helpdesk_ticket_templates.xml
+++ b/helpdesk_mgmt/views/helpdesk_ticket_templates.xml
@@ -79,6 +79,7 @@
                         <thead>
                             <tr class="active">
                                 <th>By</th>
+                                <th>Number</th>
                                 <th>Name</th>
                                 <th>Category</th>
                                 <th>Stage</th>
@@ -91,6 +92,9 @@
                             <tr>
                                 <td>
                                     <t t-esc="ticket.partner_id.name" />
+                                </td>
+                                <td>
+                                    <t t-esc="ticket.number" />
                                 </td>
                                 <td>
                                     <a t-attf-href="/my/ticket/#{ticket.id}">
@@ -165,6 +169,9 @@
                         <div class="mb8">
                             <div>
                                 <div class="pull-left">
+                                    <strong>Number:</strong>
+                                    <span t-field="ticket.number" />
+                                    <br />
                                     <strong>Date:</strong>
                                     <span t-field="ticket.create_date" />
                                     <br />


### PR DESCRIPTION
Mails sent to customers had only the number reference of the ticket, which wasn't displayed to them in the portal view. Now both ticket number and name are always displayed in email communications and in portal.