### PR TITLE
[15.0][FIX] Avoid error when creating ticked from a duplicated customer

### DIFF
--- a/helpdesk_mgmt/controllers/main.py
+++ b/helpdesk_mgmt/controllers/main.py
@@ -43,10 +43,8 @@ class HelpdeskTicketController(http.Controller):
     @http.route("/submitted/ticket", type="http", auth="user", website=True, csrf=True)
     def submit_ticket(self, **kw):
         vals = {
-            "partner_name": kw.get("name"),
             "company_id": http.request.env.user.company_id.id,
             "category_id": kw.get("category"),
-            "partner_email": kw.get("email"),
             "description": kw.get("description"),
             "name": kw.get("subject"),
             "attachment_ids": False,
@@ -54,10 +52,7 @@ class HelpdeskTicketController(http.Controller):
             .sudo()
             .search([("name", "=", "Web")])
             .id,
-            "partner_id": request.env["res.partner"]
-            .sudo()
-            .search([("name", "=", kw.get("name")), ("email", "=", kw.get("email"))])
-            .id,
+            "partner_id": request.env.user.partner_id.id,
         }
         new_ticket = request.env["helpdesk.ticket"].sudo().create(vals)
         new_ticket.message_subscribe(partner_ids=request.env.user.partner_id.ids)

--- a/helpdesk_mgmt/views/helpdesk_ticket_templates.xml
+++ b/helpdesk_mgmt/views/helpdesk_ticket_templates.xml
@@ -226,37 +226,6 @@
                 <div class="form-group">
                     <label
                         class="col-md-3 col-sm-4 control-label"
-                        for="name"
-                    >Name</label>
-                    <div class="col-md-7 col-sm-8">
-                        <input
-                            type="text"
-                            class="form-control"
-                            name="name"
-                            t-attf-value="#{name}"
-                            required="True"
-                        />
-                    </div>
-                </div>
-                <div class="form-group">
-                    <label
-                        class="col-md-3 col-sm-4 control-label"
-                        for="email"
-                    >Email</label>
-                    <div class="col-md-7 col-sm-8">
-                        <input
-                            type="email"
-                            class="form-control"
-                            name="email"
-                            required="True"
-                            t-attf-value="#{email}"
-                            readonly="True"
-                        />
-                    </div>
-                </div>
-                <div class="form-group">
-                    <label
-                        class="col-md-3 col-sm-4 control-label"
                         for="category"
                     >Category</label>
                     <div class="col-md-7 col-sm-8">


### PR DESCRIPTION
Forward port of #301 
When the client tries to create a ticket from the portal and it has a duplicate contact:
![Captura de pantalla 2022-02-20 185514](https://user-images.githubusercontent.com/43784849/154858058-fb0c9f69-0b3e-494b-af7e-426607203aa8.png)

It throws the **following error**:
![Captura de pantalla 2022-02-20 190445](https://user-images.githubusercontent.com/43784849/154857993-3647064e-bd53-4e7a-8628-5a9a9cf04ab0.png)
