### PR TITLE
[12.0] FIX helpdesk_mgmt: 403 error when user is follower of a ticket but can't access to partner_id

### DIFF
--- a/helpdesk_mgmt/controllers/myaccount.py
+++ b/helpdesk_mgmt/controllers/myaccount.py
@@ -146,7 +146,7 @@ class CustomerPortal(CustomerPortal):
         )
         values.update({
             'date': date_begin,
-            'tickets': tickets,
+            'tickets': tickets.sudo(),
             'page_name': 'ticket',
             'pager': pager,
             'default_url': '/my/tickets',


### PR DESCRIPTION

Following the same approach as https://github.com/odoo/odoo/blob/272602193f5647f7f2270ed6ec68777625a139dd/addons/sale/controllers/portal.py#L133