### PR TITLE
[helpdesk_mgmt] Change inherit order to priorize method definitions

### DIFF
--- a/helpdesk_mgmt/models/helpdesk_ticket.py
+++ b/helpdesk_mgmt/models/helpdesk_ticket.py
@@ -8,7 +8,7 @@ class HelpdeskTicket(models.Model):
     _rec_name = "number"
     _order = "number desc"
     _mail_post_access = "read"
-    _inherit = ["mail.thread.cc", "mail.activity.mixin", "portal.mixin"]
+    _inherit = ["portal.mixin", "mail.thread.cc", "mail.activity.mixin"]
 
     def _get_default_stage_id(self):
         return self.env["helpdesk.ticket.stage"].search([], limit=1).id


### PR DESCRIPTION
Helpdesk management is using portal mixin to ensure link between helpdesk ticket and access of them on the portal.

But i've done some tests to get access link to portal by notification email over _notify_get_groups method (recommended by Odoo).

When you override method from 'helpdesk.ticket' model, the super method called is the _notify_get_groups method from 'mail.thread' model cause this model is herited by tickets too. Finally the method with same name from portal mixin is never called!

I've updated order of inherits in 'helpdesk.ticket' model and i've the good process now:

- _notify_get_groups method call from my override code of helpdesk.ticket model
- _notify_get_groups method call from 'portal.mixin' model
- _notify_get_groups method call from 'mail.thread' model
