### PR TITLE
[13.0][FIX] helpdesk_mgmtsystem_nonconformity: Avoid non-existing external_id error in action_nonconformity_create()

### DIFF
--- a/helpdesk_mgmtsystem_nonconformity/models/helpdesk_ticket.py
+++ b/helpdesk_mgmtsystem_nonconformity/models/helpdesk_ticket.py
@@ -25,9 +25,6 @@ class HelpdeskTicket(models.Model):
             "manager_user_id": self.team_id.user_id.id or self.user_id.id,
             "responsible_user_id": self.team_id.user_id.id or self.user_id.id,
             "description": self.description,
-            "origin_ids": [
-                (6, 0, self.env.ref("mgmtsystem_nonconformity.demo_origin").ids)
-            ],
         }
         if stage.state == "open":
             vals.update({"action_comments": self.description})


### PR DESCRIPTION
Avoid non-existing external_id error in `action_nonconformity_create()`

Please @pedrobaeza and @CarlosRoca13 can you review it?

@Tecnativa TT38205