### PR TITLE
[14.0][IMP] helpdesk_mgmt_rating: Only managers can change rating status

### DIFF
--- a/helpdesk_mgmt_rating/views/helpdesk_ticket_views.xml
+++ b/helpdesk_mgmt_rating/views/helpdesk_ticket_views.xml
@@ -10,7 +10,7 @@
                 <b>
                     <t t-if="record.positive_rate_percentage.value != -1">
                         <a name="action_view_ticket_rating" type="object">
-                            <i class="fa fa-smile-o" role="img" /> <t
+                            <i class="fa fa-smile-o" /> <t
                                 t-esc="record.positive_rate_percentage.value"
                             />%
                         </a>
@@ -32,8 +32,11 @@
         <field name="model">helpdesk.ticket</field>
         <field name="inherit_id" ref="helpdesk_mgmt.ticket_view_form" />
         <field name="arch" type="xml">
-            <xpath expr="//div[@name='button_box']" position="inside">
+            <xpath expr="//div[hasclass('oe_title')]" position="before">
                 <field name="positive_rate_percentage" invisible="1" />
+                <field name="rating_status" invisible="1" />
+            </xpath>
+            <div name="button_box" position="inside">
                 <button
                     name="action_view_ticket_rating"
                     type="object"
@@ -43,7 +46,18 @@
                 >
                     <field name="rating_count" widget="statinfo" string="Ratings" />
                 </button>
-            </xpath>
+            </div>
+        </field>
+    </record>
+    <record id="ticket_view_form_rating_status" model="ir.ui.view">
+        <field name="name">ticket.view.form: Rating status</field>
+        <field name="model">helpdesk.ticket</field>
+        <field name="inherit_id" ref="helpdesk_mgmt.ticket_view_form" />
+        <field
+            name="groups_id"
+            eval="[(4, ref('helpdesk_mgmt.group_helpdesk_manager'))]"
+        />
+        <field name="arch" type="xml">
             <xpath expr="//group[@name='main']/group[2]" position="after">
                 <group>
                     <field name="rating_status" widget="radio" />


### PR DESCRIPTION
Allowing any helpdesk user to change the rating status (to be rated or
not) may lead to bad manipulations by these users, so we protect the
field to only be changed by helpdesk managers.

TT33737 

Cherry-pick of https://github.com/OCA/helpdesk/commit/4493c8818f7ec6c54de8ad81e1e80b3b58c26246

please @pedrobaeza @chienandalu 