### PR TITLE
[13.0][FIX] helpdesk_mgmt: New ticket from portal

### DIFF
--- a/helpdesk_mgmt/README.rst
+++ b/helpdesk_mgmt/README.rst
@@ -191,6 +191,7 @@ Contributors
 * `Tecnativa <https://www.tecnativa.com>`_:
 
   * Pedro M. Baeza
+  * Víctor Martínez
 
 * `ID42 Sistemas <https://www.id42.com.br>`_:
 

--- a/helpdesk_mgmt/controllers/main.py
+++ b/helpdesk_mgmt/controllers/main.py
@@ -42,9 +42,12 @@ class HelpdeskTicketController(http.Controller):
 
     @http.route("/submitted/ticket", type="http", auth="user", website=True, csrf=True)
     def submit_ticket(self, **kw):
+        category = http.request.env["helpdesk.ticket.category"].browse(
+            int(kw.get("category"))
+        )
         vals = {
-            "company_id": http.request.env.user.company_id.id,
-            "category_id": kw.get("category"),
+            "company_id": category.company_id.id or http.request.env.user.company_id.id,
+            "category_id": category.id,
             "description": kw.get("description"),
             "name": kw.get("subject"),
             "attachment_ids": False,

--- a/helpdesk_mgmt/controllers/main.py
+++ b/helpdesk_mgmt/controllers/main.py
@@ -71,4 +71,4 @@ class HelpdeskTicketController(http.Controller):
                             "res_id": new_ticket.id,
                         }
                     )
-        return werkzeug.utils.redirect("/my/tickets")
+        return werkzeug.utils.redirect("/my/ticket/%s" % new_ticket.id)

--- a/helpdesk_mgmt/controllers/myaccount.py
+++ b/helpdesk_mgmt/controllers/myaccount.py
@@ -10,10 +10,7 @@ from odoo.addons.portal.controllers.portal import CustomerPortal, pager as porta
 class CustomerPortalHelpdesk(CustomerPortal):
     def _prepare_portal_layout_values(self):
         values = super()._prepare_portal_layout_values()
-        partner = request.env.user.partner_id
-        ticket_count = request.env["helpdesk.ticket"].search_count(
-            [("partner_id", "child_of", partner.id)]
-        )
+        ticket_count = request.env["helpdesk.ticket"].search_count([])
         values["ticket_count"] = ticket_count
         return values
 

--- a/helpdesk_mgmt/readme/CONTRIBUTORS.rst
+++ b/helpdesk_mgmt/readme/CONTRIBUTORS.rst
@@ -26,6 +26,7 @@
 * `Tecnativa <https://www.tecnativa.com>`_:
 
   * Pedro M. Baeza
+  * Víctor Martínez
 
 * `ID42 Sistemas <https://www.id42.com.br>`_:
 

--- a/helpdesk_mgmt/static/description/index.html
+++ b/helpdesk_mgmt/static/description/index.html
@@ -3,7 +3,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-<meta name="generator" content="Docutils 0.15.1: http://docutils.sourceforge.net/" />
+<meta name="generator" content="Docutils: http://docutils.sourceforge.net/" />
 <title>Helpdesk Management</title>
 <style type="text/css">
 
@@ -544,6 +544,7 @@ If you spotted it first, help us smashing it by providing a detailed and welcome
 </li>
 <li><a class="reference external" href="https://www.tecnativa.com">Tecnativa</a>:<ul>
 <li>Pedro M. Baeza</li>
+<li>Víctor Martínez</li>
 </ul>
 </li>
 <li><a class="reference external" href="https://www.id42.com.br">ID42 Sistemas</a>:<ul>


### PR DESCRIPTION
Changes done:
- Show the correct total of tickets in the portal (before, the total was filtered by those of the user's partner, but all the ones to which the user had access were shown in the list).
- Ticket creation from the portal with the category company (if set) or the user's default company.
- Redirect to the ticket created from the portal.

Please @pedrobaeza and @chienandalu can you review it?

@Tecnativa TT38426