### PR TITLE
[15.0][FIX] Update copier template

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,9 +1,14 @@
 # Do NOT update manually; changes here will be overwritten by Copier
-_commit: v1.5.2
+_commit: v1.11.0
 _src_path: gh:oca/oca-addons-repo-template
 ci: GitHub
 dependency_installation_mode: PIP
 generate_requirements_txt: true
+github_check_license: true
+github_enable_codecov: true
+github_enable_makepot: true
+github_enable_stale_action: true
+github_enforce_dev_status_compatibility: true
 include_wkhtmltopdf: false
 odoo_version: 15.0
 org_name: Odoo Community Association (OCA)
@@ -15,3 +20,4 @@ repo_slug: helpdesk
 repo_website: https://github.com/OCA/helpdesk
 travis_apt_packages: []
 travis_apt_sources: []
+

--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,6 @@ build/
 develop-eggs/
 dist/
 eggs/
-lib/
 lib64/
 parts/
 sdist/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -119,19 +119,15 @@ repos:
       - id: flake8
         name: flake8
         additional_dependencies: ["flake8-bugbear==21.9.2"]
-  - repo: https://github.com/PyCQA/pylint
-    rev: v2.11.1
+  - repo: https://github.com/OCA/pylint-odoo
+    rev: 7.0.2
     hooks:
-      - id: pylint
+      - id: pylint_odoo
         name: pylint with optional checks
         args:
           - --rcfile=.pylintrc
           - --exit-zero
         verbose: true
-        additional_dependencies: &pylint_deps
-          - pylint-odoo==5.0.5
-      - id: pylint
-        name: pylint with mandatory checks
+      - id: pylint_odoo
         args:
           - --rcfile=.pylintrc-mandatory
-        additional_dependencies: *pylint_deps

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,3 +1,5 @@
+
+
 [MASTER]
 load-plugins=pylint_odoo
 score=n

--- a/.pylintrc-mandatory
+++ b/.pylintrc-mandatory
@@ -1,3 +1,4 @@
+
 [MASTER]
 load-plugins=pylint_odoo
 score=n


### PR DESCRIPTION
To avoid library versions problem with Python 3.11