### PR TITLE
[IMP] helpdesk_mgmt: Modernize ticket portal views

### DIFF
--- a/helpdesk_mgmt/controllers/myaccount.py
+++ b/helpdesk_mgmt/controllers/myaccount.py
@@ -1,13 +1,22 @@
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
 
+from collections import OrderedDict
+from operator import itemgetter
+
 from odoo import _, http
 from odoo.exceptions import AccessError, MissingError
 from odoo.http import request
+from odoo.osv.expression import AND, OR
+from odoo.tools import groupby as groupbyelem
 
 from odoo.addons.portal.controllers.portal import CustomerPortal, pager as portal_pager
 
 
 class CustomerPortalHelpdesk(CustomerPortal):
+    """Routes called in portal mode to manage tickets.
+    Very similar to those in the "project" module defined to manage tasks.
+    """
+
     def _prepare_home_portal_values(self, counters):
         values = super()._prepare_home_portal_values(counters)
         if "ticket_count" in counters:
@@ -27,70 +36,129 @@ class CustomerPortalHelpdesk(CustomerPortal):
         website=True,
     )
     def portal_my_tickets(
-        self, page=1, date_begin=None, date_end=None, sortby=None, filterby=None, **kw
+        self,
+        page=1,
+        date_begin=None,
+        date_end=None,
+        sortby=None,
+        filterby=None,
+        search=None,
+        search_in=None,
+        groupby=None,
+        **kw
     ):
-        values = self._prepare_portal_layout_values()
         HelpdeskTicket = request.env["helpdesk.ticket"]
         # Avoid error if the user does not have access.
         if not HelpdeskTicket.check_access_rights("read", raise_exception=False):
             return request.redirect("/my")
 
-        domain = []
+        values = self._prepare_portal_layout_values()
 
-        searchbar_sortings = {
-            "date": {"label": _("Newest"), "order": "create_date desc"},
-            "name": {"label": _("Name"), "order": "name"},
-            "stage": {"label": _("Stage"), "order": "stage_id"},
-            "update": {
-                "label": _("Last Stage Update"),
-                "order": "last_stage_update desc",
-            },
-        }
-        searchbar_filters = {"all": {"label": _("All"), "domain": []}}
-        for stage in request.env["helpdesk.ticket.stage"].search([]):
-            searchbar_filters.update(
-                {
-                    str(stage.id): {
-                        "label": stage.name,
-                        "domain": [("stage_id", "=", stage.id)],
-                    }
-                }
+        searchbar_sortings = self._ticket_get_searchbar_sortings()
+        searchbar_sortings = dict(
+            sorted(
+                self._ticket_get_searchbar_sortings().items(),
+                key=lambda item: item[1]["sequence"],
             )
+        )
 
-        # default sort by order
+        searchbar_filters = {
+            "all": {"label": _("All"), "domain": []},
+        }
+        for stage in request.env["helpdesk.ticket.stage"].search([]):
+            searchbar_filters[str(stage.id)] = {
+                "label": stage.name,
+                "domain": [("stage_id", "=", stage.id)],
+            }
+
+        searchbar_inputs = self._ticket_get_searchbar_inputs()
+        searchbar_groupby = self._ticket_get_searchbar_groupby()
+
         if not sortby:
             sortby = "date"
         order = searchbar_sortings[sortby]["order"]
 
-        # default filter by value
         if not filterby:
             filterby = "all"
-        domain += searchbar_filters[filterby]["domain"]
+        domain = searchbar_filters.get(filterby, searchbar_filters.get("all"))["domain"]
+
+        if not groupby:
+            groupby = "none"
+
+        if date_begin and date_end:
+            domain += [
+                ("create_date", ">", date_begin),
+                ("create_date", "<=", date_end),
+            ]
+
+        if not search_in:
+            search_in = "all"
+        if search:
+            domain += self._ticket_get_search_domain(search_in, search)
+
+        domain = AND(
+            [
+                domain,
+                request.env["ir.rule"]._compute_domain(HelpdeskTicket._name, "read"),
+            ]
+        )
 
         # count for pager
         ticket_count = HelpdeskTicket.search_count(domain)
         # pager
         pager = portal_pager(
             url="/my/tickets",
-            url_args={},
+            url_args={
+                "date_begin": date_begin,
+                "date_end": date_end,
+                "sortby": sortby,
+                "filterby": filterby,
+                "groupby": groupby,
+                "search": search,
+                "search_in": search_in,
+            },
             total=ticket_count,
             page=page,
             step=self._items_per_page,
         )
-        # content according to pager and archive selected
+
+        order = self._ticket_get_order(order, groupby)
         tickets = HelpdeskTicket.search(
-            domain, order=order, limit=self._items_per_page, offset=pager["offset"]
+            domain,
+            order=order,
+            limit=self._items_per_page,
+            offset=pager["offset"],
         )
+        request.session["my_tickets_history"] = tickets.ids[:100]
+
+        groupby_mapping = self._ticket_get_groupby_mapping()
+        group = groupby_mapping.get(groupby)
+        if group:
+            grouped_tickets = [
+                request.env["helpdesk.ticket"].concat(*g)
+                for k, g in groupbyelem(tickets, itemgetter(group))
+            ]
+        elif tickets:
+            grouped_tickets = [tickets]
+        else:
+            grouped_tickets = []
+
         values.update(
             {
                 "date": date_begin,
-                "tickets": tickets,
+                "date_end": date_end,
+                "grouped_tickets": grouped_tickets,
                 "page_name": "ticket",
-                "pager": pager,
                 "default_url": "/my/tickets",
+                "pager": pager,
                 "searchbar_sortings": searchbar_sortings,
+                "searchbar_groupby": searchbar_groupby,
+                "searchbar_inputs": searchbar_inputs,
+                "search_in": search_in,
+                "search": search,
                 "sortby": sortby,
-                "searchbar_filters": searchbar_filters,
+                "groupby": groupby,
+                "searchbar_filters": OrderedDict(sorted(searchbar_filters.items())),
                 "filterby": filterby,
             }
         )
@@ -99,31 +167,95 @@ class CustomerPortalHelpdesk(CustomerPortal):
     @http.route(
         ["/my/ticket/<int:ticket_id>"], type="http", auth="public", website=True
     )
-    def portal_my_ticket(self, ticket_id=None, access_token=None, **kw):
+    def portal_my_ticket(self, ticket_id, access_token=None, **kw):
         try:
             ticket_sudo = self._document_check_access(
                 "helpdesk.ticket", ticket_id, access_token=access_token
             )
         except (AccessError, MissingError):
             return request.redirect("/my")
-        values = self._ticket_get_page_view_values(ticket_sudo, **kw)
+
+        # ensure attachments are accessible with access token inside template
+        for attachment in ticket_sudo.attachment_ids:
+            attachment.generate_access_token()
+        values = self._ticket_get_page_view_values(ticket_sudo, access_token, **kw)
         return request.render("helpdesk_mgmt.portal_helpdesk_ticket_page", values)
 
-    def _ticket_get_page_view_values(self, ticket, **kwargs):
+    def _ticket_get_page_view_values(self, ticket, access_token, **kwargs):
         closed_stages = request.env["helpdesk.ticket.stage"].search(
             [("closed", "=", True)]
         )
         values = {
+            "closed_stages": closed_stages,
             "page_name": "ticket",
             "ticket": ticket,
-            "closed_stages": closed_stages,
+            "user": request.env.user,
+        }
+        return self._get_page_view_values(
+            ticket, access_token, values, "my_tickets_history", False, **kwargs
+        )
+
+    def _ticket_get_searchbar_sortings(self):
+        return {
+            "date": {
+                "label": _("Newest"),
+                "order": "create_date desc",
+                "sequence": 1,
+            },
+            "name": {"label": _("Title"), "order": "name", "sequence": 2},
+            "stage": {"label": _("Stage"), "order": "stage_id", "sequence": 3},
+            "update": {
+                "label": _("Last Stage Update"),
+                "order": "last_stage_update desc",
+                "sequence": 4,
+            },
         }
 
-        if kwargs.get("error"):
-            values["error"] = kwargs["error"]
-        if kwargs.get("warning"):
-            values["warning"] = kwargs["warning"]
-        if kwargs.get("success"):
-            values["success"] = kwargs["success"]
+    def _ticket_get_searchbar_groupby(self):
+        values = {
+            "none": {"input": "none", "label": _("None"), "order": 1},
+            "category": {
+                "input": "category",
+                "label": _("Category"),
+                "order": 2,
+            },
+            "stage": {"input": "stage", "label": _("Stage"), "order": 3},
+        }
+        return dict(sorted(values.items(), key=lambda item: item[1]["order"]))
 
-        return values
+    def _ticket_get_searchbar_inputs(self):
+        values = {
+            "all": {"input": "all", "label": _("Search in All"), "order": 1},
+            "number": {
+                "input": "number",
+                "label": _("Search in Number"),
+                "order": 2,
+            },
+            "name": {
+                "input": "name",
+                "label": _("Search in Title"),
+                "order": 3,
+            },
+        }
+        return dict(sorted(values.items(), key=lambda item: item[1]["order"]))
+
+    def _ticket_get_search_domain(self, search_in, search):
+        search_domain = []
+        if search_in in ("number", "all"):
+            search_domain.append([("number", "ilike", search)])
+        if search_in in ("name", "all"):
+            search_domain.append([("name", "ilike", search)])
+        return OR(search_domain)
+
+    def _ticket_get_groupby_mapping(self):
+        return {
+            "category": "category_id",
+            "stage": "stage_id",
+        }
+
+    def _ticket_get_order(self, order, groupby):
+        groupby_mapping = self._ticket_get_groupby_mapping()
+        field_name = groupby_mapping.get(groupby, "")
+        if not field_name:
+            return order
+        return "%s, %s" % (field_name, order)

--- a/helpdesk_mgmt/tests/test_portal.py
+++ b/helpdesk_mgmt/tests/test_portal.py
@@ -32,7 +32,9 @@ class TestPortal(HttpCaseWithUserPortal):
         resp = self.url_open(f"/my/ticket/{self.portal_ticket.id}")
         self.assertEqual(resp.status_code, 200)
         self.assertIn("portal-ticket-title", resp.text)
-        self.assertIn('<h4 class="page-header">History</h4>', resp.text)
+        self.assertIn(
+            "<h4><strong>Message and communication history</strong></h4>", resp.text
+        )
 
     def test_submit_ticket(self):
         """Submit a ticket in portal mode."""

--- a/helpdesk_mgmt/views/helpdesk_ticket_templates.xml
+++ b/helpdesk_mgmt/views/helpdesk_ticket_templates.xml
@@ -4,7 +4,7 @@
         id="portal_layout"
         name="Portal layout: ticket menu entry"
         inherit_id="portal.portal_breadcrumbs"
-        priority="50"
+        priority="40"
     >
         <xpath expr="//ol[hasclass('o_portal_submenu')]" position="inside">
             <li
@@ -17,16 +17,18 @@
                 >Tickets</a>
                 <t t-else="">Tickets</t>
             </li>
-            <li t-if="ticket" class="breadcrumb-item active">
-                <t t-esc="ticket.name" />
+            <li t-if="ticket" class="breadcrumb-item active text-truncate">
+                <span t-field="ticket.name" />
             </li>
         </xpath>
     </template>
+
     <template
         id="portal_my_home"
         name="Portal My Home : ticket entries"
         inherit_id="portal.portal_my_home"
         priority="40"
+        customize_show="True"
     >
         <xpath expr="//div[hasclass('o_portal_docs')]" position="inside">
             <t t-call="portal.portal_docs_entry">
@@ -44,66 +46,102 @@
                     name="create_new_ticket"
                     type="action"
                     class="btn btn-primary"
-                    style="float: right; margin-right: 0px; margin-top:5px;"
+                    style="float: right; margin-right: 0px; margin-bottom: 5px;"
                 >New Ticket</button>
             </form>
         </xpath>
     </template>
-    <template id="portal_my_tickets" name="My tickets">
+
+    <template id="portal_my_tickets" name="My Tickets">
         <t t-call="portal.portal_layout">
             <t t-set="breadcrumbs_searchbar" t-value="True" />
+
+            <t t-call="portal.portal_searchbar">
+                <t t-set="title">Tickets</t>
+            </t>
+
             <form method="POST" t-attf-action="/new/ticket">
-                <h3>Tickets
-            <t t-call="portal.portal_searchbar" />
-            <button
-                        name="create_new_ticket"
-                        type="action"
-                        class="btn btn-primary"
-                        style="float: right; margin-right: 5px;"
-                    >New Ticket</button>
-          </h3>
+                <button
+                    name="create_new_ticket"
+                    type="action"
+                    class="btn btn-primary"
+                    style="float: right; margin-right: 0px; margin-bottom: 5px;"
+                >New Ticket</button>
                 <input
                     type="hidden"
                     name="csrf_token"
                     t-att-value="request.csrf_token()"
                 />
             </form>
-            <t t-if="not tickets">
-                <p>There are no tickets in your account.</p>
+
+            <t t-if="not grouped_tickets">
+                <div class="alert alert-warning mt8" role="alert">
+                    <p>No tickets found.</p>
+                </div>
             </t>
-            <div t-if="tickets" class="panel panel-default">
-                <div class="table-responsive">
-                    <table class="table table-hover o_portal_my_doc_table">
-                        <thead>
-                            <tr class="active">
-                                <th>By</th>
-                                <th>Number</th>
-                                <th>Name</th>
-                                <th>Category</th>
-                                <th>Stage</th>
+            <t t-call="helpdesk_mgmt.portal_ticket_list" />
+        </t>
+    </template>
+
+    <template id="portal_ticket_list" name="Ticket List">
+        <t t-if="grouped_tickets">
+            <t t-call="portal.portal_table">
+                <t t-foreach="grouped_tickets" t-as="tickets">
+                    <thead>
+                        <tr
+                            t-attf-class="{{'thead-light' if not groupby == 'none' else ''}}"
+                        >
+                                <th class="text-left">By</th>
+                                <th class="text-left">Number</th>
+                                <th t-if="groupby == 'none'">Title</th>
+                                <th t-if="groupby == 'category'">
+                                    <em
+                                    class="font-weight-normal text-muted"
+                                >Tickets in category:</em>
+                                    <span
+                                    class="text-truncate"
+                                    t-field="tickets[0].sudo().category_id.name"
+                                /></th>
+                                <th t-if="groupby == 'stage'">
+                                    <em
+                                    class="font-weight-normal text-muted"
+                                >Tickets in stage:</em>
+                                    <span
+                                    class="text-truncate"
+                                    t-field="tickets[0].sudo().stage_id.name"
+                                /></th>
+                                <th t-if="groupby != 'category'">Category</th>
+                                <th t-if="groupby != 'stage'">Stage</th>
                                 <th>Create Date</th>
                                 <th>Last Stage Update</th>
                                 <th>Close Date</th>
-                            </tr>
-                        </thead>
+                        </tr>
+                    </thead>
+                    <tbody>
                         <t t-foreach="tickets" t-as="ticket">
                             <tr>
-                                <td>
-                                    <t t-esc="ticket.partner_id.name" />
+                                <td class="text-left">
+                                    <span t-esc="ticket.partner_id.name" />
+                                </td>
+                                <td class="text-left">
+                                    <span t-esc="ticket.number" />
                                 </td>
                                 <td>
-                                    <t t-esc="ticket.number" />
-                                </td>
-                                <td>
-                                    <a t-attf-href="/my/ticket/#{ticket.id}">
-                                        <t t-esc="ticket.name" />
+                                    <a
+                                        t-attf-href="/my/ticket/#{ticket.id}?{{ keep_query() }}"
+                                    >
+                                        <span t-field="ticket.name" />
                                     </a>
                                 </td>
-                                <td>
-                                    <t t-esc="ticket.category_id.name" />
+                                <td t-if="groupby != 'category'">
+                                    <span t-esc="ticket.category_id.name" />
                                 </td>
-                                <td>
-                                    <t t-esc="ticket.stage_id.name" />
+                                <td t-if="groupby != 'stage'">
+                                    <span
+                                        class="badge badge-pill badge-info"
+                                        title="Current stage of the ticket"
+                                        t-esc="ticket.stage_id.name"
+                                    />
                                 </td>
                                 <td>
                                     <span t-field="ticket.create_date" />
@@ -116,93 +154,228 @@
                                 </td>
                             </tr>
                         </t>
-                    </table>
-                </div>
-                <div t-if="pager" class="o_portal_pager text-center">
-                    <t t-call="portal.pager" />
-                </div>
-            </div>
+                    </tbody>
+                </t>
+            </t>
         </t>
     </template>
+
     <template id="portal_helpdesk_ticket_page" name="Ticket Portal Template">
         <t t-call="portal.portal_layout">
-            <div class="container">
-                <div class="panel panel-default">
-                    <div class="panel-heading">
-                        <div class="row">
-                            <div class="col-md-6">
-                                <h4>
-                                    <t t-call='portal.record_pager' />
-                                    <span t-field="ticket.name" />
-                                </h4>
-                            </div>
-                            <t t-foreach="closed_stages" t-as="stage">
-                                <form
-                                    method="GET"
-                                    t-if="not ticket.closed_date"
-                                    t-attf-action="/ticket/close"
-                                    style="display:inline;"
-                                >
-                                    <input
-                                        type="hidden"
-                                        name="ticket_id"
-                                        t-attf-value="#{ticket.id}"
+            <t t-call="portal.portal_record_layout">
+                <t t-set="card_header">
+                    <div class="row no-gutters">
+                        <div class="col-12">
+                            <h5 class="d-flex mb-1 mb-md-0 row">
+                                <div class="col-9">
+                                    <span t-field="ticket.name" class="text-truncate" />
+                                    <small class="text-muted d-none d-md-inline"> (<span
+                                            t-field="ticket.number"
+                                        />)</small>
+                                </div>
+                                <div class="col-3 text-right">
+                                    <small class="text-right">Stage:</small>
+                                    <span
+                                        t-field="ticket.stage_id.name"
+                                        class=" badge badge-pill badge-info"
+                                        title="Current stage of this ticket"
                                     />
-                                    <input
-                                        type="hidden"
-                                        name="stage_id"
-                                        t-attf-value="#{stage.id}"
-                                    />
-                                    <button
-                                        class="btn btn-success pull-right"
-                                        style="margin-right:15px;margin-top:3px;"
+                                </div>
+                            </h5>
+                        </div>
+                    </div>
+                </t>
+
+                <t t-set="card_body">
+                    <div class="row mb-4">
+                        <div class="col-12 col-md-6" name="portal_ticket_col_0">
+                            <div><strong>Date:</strong> <span
+                                    t-field="ticket.create_date"
+                                    t-options='{"widget": "datetime"}'
+                                /></div>
+                            <div><strong>Category:</strong> <span
+                                    t-field="ticket.category_id"
+                                /></div>
+                        </div>
+                        <div
+                            class="col-12 col-md-6 text-right"
+                            name="portal_ticket_col_1"
+                        >
+                            <div><strong>Last Stage Update:</strong> <span
+                                    t-field="ticket.last_stage_update"
+                                    t-options='{"widget": "datetime"}'
+                                /></div>
+                            <div t-if="ticket.closed_date"><strong
+                                >Close Date:</strong> <span
+                                    t-field="ticket.closed_date"
+                                    t-options='{"widget": "datetime"}'
+                                /></div>
+                            <div
+                                t-if="not ticket.closed_date"
+                                name="ticket_close_buttons"
+                            >
+                                <t t-foreach="closed_stages" t-as="stage">
+                                    <form
+                                        method="GET"
+                                        t-attf-action="/ticket/close"
+                                        style="display:inline;"
                                     >
-                                        <span t-field="stage.name" />
-                                    </button>
-                                </form>
-                            </t>
+                                        <input
+                                            type="hidden"
+                                            name="ticket_id"
+                                            t-attf-value="#{ticket.id}"
+                                        />
+                                        <input
+                                            type="hidden"
+                                            name="stage_id"
+                                            t-attf-value="#{stage.id}"
+                                        />
+                                        <button
+                                            class="btn btn-outline-primary"
+                                            style="font-size: small; padding: 4px;"
+                                        >
+                                            <span t-field="stage.name" />
+                                        </button>
+                                    </form>
+                                </t>
+                            </div>
                         </div>
                     </div>
-                    <div class="panel-body">
-                        <div class="mb8">
-                            <div>
-                                <div class="pull-left">
-                                    <strong>Number:</strong>
-                                    <span t-field="ticket.number" />
-                                    <br />
-                                    <strong>Date:</strong>
-                                    <span t-field="ticket.create_date" />
-                                    <br />
-                                    <b>Category:</b>
-                                    <t t-esc="ticket.category_id.name" />
-                                    <br />
-                                    <b>Stage:</b>
-                                    <t t-esc="ticket.stage_id.name" />
-                                    <br />
+
+                    <div class="row mt-3" t-if="ticket.user_id or ticket.partner_id">
+                        <div class="col-12 col-md-6 pb-2" t-if="ticket.user_id">
+                            <strong>Assignee</strong>
+                            <div class="row">
+                                <div
+                                    class="col d-flex align-items-center flex-grow-0 pr-3"
+                                >
+                                    <img
+                                        class="rounded-circle mt-1 o_portal_contact_img"
+                                        t-att-src="image_data_uri(ticket.user_id.avatar_1024)"
+                                        alt="Contact"
+                                    />
                                 </div>
-                                <div class="pull-right">
-                                    <strong>Last Stage Update:</strong>
-                                    <span t-field="ticket.last_stage_update" />
-                                    <br />
+                                <div class="col pl-md-0">
+                                    <div
+                                        t-esc="ticket.user_id"
+                                        t-options='{"widget": "contact", "fields": ["name"]}'
+                                    />
+                                    <a
+                                        t-attf-href="mailto:{{ticket.user_id.email}}"
+                                        t-if="ticket.user_id.email"
+                                    ><div
+                                            t-esc="ticket.user_id"
+                                            t-options='{"widget": "contact", "fields": ["email"]}'
+                                        /></a>
+                                    <a
+                                        t-attf-href="tel:{{ticket.user_id.phone}}"
+                                        t-if="ticket.user_id.phone"
+                                    ><div
+                                            t-esc="ticket.user_id"
+                                            t-options='{"widget": "contact", "fields": ["phone"]}'
+                                        /></a>
                                 </div>
                             </div>
-                            <br />
-                            <br />
-                            <h4 class="page-header">Description</h4>
-                            <t t-raw="ticket.description" />
-                            <br />
                         </div>
-                        <h4 class="page-header">History</h4>
-                        <!-- Options:Ticket Chatter: user can reply -->
-                        <t t-call="portal.message_thread">
-                            <t t-set="object" t-value="ticket" />
-                        </t>
+                        <div class="col-12 col-md-6 pb-2" t-if="ticket.partner_id">
+                            <strong>Customer</strong>
+                            <div class="row">
+                                <div
+                                    class="col d-flex align-items-center flex-grow-0 pr-3"
+                                >
+                                    <img
+                                        class="rounded-circle mt-1 o_portal_contact_img"
+                                        t-att-src="image_data_uri(ticket.partner_id.avatar_1024)"
+                                        alt="Contact"
+                                    />
+                                </div>
+                                <div class="col pl-md-0">
+                                    <div
+                                        t-field="ticket.partner_id"
+                                        t-options='{"widget": "contact", "fields": ["name"]}'
+                                    />
+                                    <a
+                                        t-attf-href="mailto:{{ticket.partner_id.email}}"
+                                        t-if="ticket.partner_id.email"
+                                    ><div
+                                            t-field="ticket.partner_id"
+                                            t-options='{"widget": "contact", "fields": ["email"]}'
+                                        /></a>
+                                    <a
+                                        t-attf-href="tel:{{ticket.partner_id.phone}}"
+                                        t-if="ticket.partner_id.phone"
+                                    ><div
+                                            t-field="ticket.partner_id"
+                                            t-options='{"widget": "contact", "fields": ["phone"]}'
+                                        /></a>
+                                </div>
+                            </div>
+                        </div>
                     </div>
-                </div>
+
+                    <div class="row" t-if="ticket.description or ticket.attachment_ids">
+                        <div
+                            t-if="ticket.description"
+                            t-attf-class="col-12 col-lg-7 mb-4 mb-md-0 {{'col-lg-7' if ticket.attachment_ids else 'col-lg-12'}}"
+                        >
+                            <hr class="mb-1" />
+                            <div class="d-flex my-2">
+                                <strong>Description</strong>
+                            </div>
+                            <div
+                                class="py-1 px-2 bg-100 small"
+                                t-field="ticket.description"
+                            />
+                        </div>
+                        <div
+                            t-if="ticket.attachment_ids"
+                            t-attf-class="col-12 col-lg-5 o_project_portal_attachments {{'col-lg-5' if ticket.description else 'col-lg-12'}}"
+                        >
+                            <hr class="mb-1 d-none d-lg-block" />
+                            <strong class="d-block mb-2">Attachments</strong>
+                            <div class="row">
+                                <div
+                                    t-attf-class="col {{'col-lg-6' if not ticket.description else 'col-lg-12'}}"
+                                >
+                                    <ul class="list-group">
+                                        <a
+                                            class="list-group-item list-group-item-action d-flex align-items-center oe_attachments py-1 px-2"
+                                            t-foreach='ticket.attachment_ids'
+                                            t-as='attachment'
+                                            t-attf-href="/web/content/#{attachment.id}?download=true&amp;access_token=#{attachment.access_token}"
+                                            target="_blank"
+                                            data-no-post-process=""
+                                        >
+                                            <div
+                                                class='oe_attachment_embedded o_image o_image_small mr-2 mr-lg-3'
+                                                t-att-title="attachment.name"
+                                                t-att-data-mimetype="attachment.mimetype"
+                                                t-attf-data-src="/web/image/#{attachment.id}/50x40?access_token=#{attachment.access_token}"
+                                            />
+                                            <div
+                                                class='oe_attachment_name text-truncate'
+                                            ><t t-esc='attachment.name' /></div>
+                                        </a>
+                                    </ul>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </t>
+            </t>
+
+            <div class="mt32">
+                <h4><strong>Message and communication history</strong></h4>
+                <t t-call="portal.message_thread">
+                    <t t-set="object" t-value="ticket" />
+                    <t t-set="token" t-value="ticket.access_token" />
+                    <t t-set="pid" t-value="pid" />
+                    <t t-set="hash" t-value="hash" />
+                </t>
             </div>
-            <div class="oe_structure mb32" />
         </t>
     </template>
+
     <template id="portal_create_ticket" name="Create Ticket">
         <t t-call="portal.portal_layout">
             <div class="container">


### PR DESCRIPTION
Bring 15.0 ticket list & form views shown in portal mode in line with those defined in the "project" module to display tasks.

While most elements remain the same, this cset also adds:
* List: group-by & search filters.
* Form: close date, assigned user, attachments.

See screenshots in https://github.com/OCA/helpdesk/pull/341#issuecomment-1240367058 for a comparison of these portal views between tickets & tasks.

Screenshots from my env, mostly demo data, hope you don't mind partial French translations:

* Ticket list, not grouped:
![Screenshot at 2022-11-08 18-05-53](https://user-images.githubusercontent.com/6347423/200629684-cd12a3cf-521a-4fd3-aba7-117be6bd5924.png)
* Ticket list, grouped by stage:
![Screenshot at 2022-11-08 18-07-28](https://user-images.githubusercontent.com/6347423/200629909-37072621-ff07-42fa-8e48-c655d2f52a72.png)
* Ticket form, not closed, has 1 attachment:
![Screenshot at 2022-11-08 18-09-38](https://user-images.githubusercontent.com/6347423/200630324-96c31793-1169-4716-a301-84d87b508fed.png)
* Ticket form, closed, multiline description with some fancy HTML, no attachments:
![Screenshot at 2022-11-08 18-08-44](https://user-images.githubusercontent.com/6347423/200630172-ae25a531-a639-4e84-8515-1eadf44103fd.png)