### PR TITLE
[15.0][FIX] helpdesk_mgmt: Preserve line breaks

### DIFF
--- a/helpdesk_mgmt/controllers/main.py
+++ b/helpdesk_mgmt/controllers/main.py
@@ -5,6 +5,7 @@ import werkzeug
 
 import odoo.http as http
 from odoo.http import request
+from odoo.tools import plaintext2html
 
 _logger = logging.getLogger(__name__)
 
@@ -48,7 +49,7 @@ class HelpdeskTicketController(http.Controller):
         vals = {
             "company_id": category.company_id.id or http.request.env.user.company_id.id,
             "category_id": category.id,
-            "description": kw.get("description"),
+            "description": plaintext2html(kw.get("description")),
             "name": kw.get("subject"),
             "attachment_ids": False,
             "channel_id": request.env["helpdesk.ticket.channel"]


### PR DESCRIPTION
on tickets submitted from the portal.

Rely on `plaintext2html`, same as Odoo in its controller for message threads (`/odoo15/addons/portal/controllers/mail.py`).

Existing portal test adapted to check this.