### PR TITLE
[14.0] [FIX] helpdesk_mgmt: sets the reply email in helpdesk team if any

### DIFF
--- a/helpdesk_mgmt/models/helpdesk_ticket.py
+++ b/helpdesk_mgmt/models/helpdesk_ticket.py
@@ -261,3 +261,24 @@ class HelpdeskTicket(models.Model):
             # imply modifying followers
             pass
         return recipients
+
+    def _notify_get_reply_to(
+        self, default=None, records=None, company=None, doc_names=None
+    ):
+        """Override to set alias of tasks to their team if any."""
+        aliases = (
+            self.sudo()
+            .mapped("team_id")
+            ._notify_get_reply_to(
+                default=default, records=None, company=company, doc_names=None
+            )
+        )
+        res = {ticket.id: aliases.get(ticket.team_id.id) for ticket in self}
+        leftover = self.filtered(lambda rec: not rec.team_id)
+        if leftover:
+            res.update(
+                super(HelpdeskTicket, leftover)._notify_get_reply_to(
+                    default=default, records=None, company=company, doc_names=doc_names
+                )
+            )
+        return res


### PR DESCRIPTION
When sending an email from a ticket, the reply email is not set with the team one. 