### PR TITLE
[15.0][IMP] helpdesk_mgmt: Add "close from portal" option & test

### DIFF
--- a/helpdesk_mgmt/controllers/main.py
+++ b/helpdesk_mgmt/controllers/main.py
@@ -25,7 +25,9 @@ class HelpdeskTicketController(http.Controller):
             .sudo()
             .search([("id", "=", values["ticket_id"])])
         )
-        ticket.stage_id = values.get("stage_id")
+        stage = http.request.env["helpdesk.ticket.stage"].browse(values.get("stage_id"))
+        if stage.close_from_portal:  # protect against invalid target stage request
+            ticket.stage_id = values.get("stage_id")
 
         return werkzeug.utils.redirect("/my/ticket/" + str(ticket.id))
 

--- a/helpdesk_mgmt/controllers/myaccount.py
+++ b/helpdesk_mgmt/controllers/myaccount.py
@@ -183,10 +183,10 @@ class CustomerPortalHelpdesk(CustomerPortal):
 
     def _ticket_get_page_view_values(self, ticket, access_token, **kwargs):
         closed_stages = request.env["helpdesk.ticket.stage"].search(
-            [("closed", "=", True)]
+            [("close_from_portal", "=", True)]
         )
         values = {
-            "closed_stages": closed_stages,
+            "closed_stages": closed_stages,  # used to display close buttons
             "page_name": "ticket",
             "ticket": ticket,
             "user": request.env.user,

--- a/helpdesk_mgmt/data/helpdesk_data.xml
+++ b/helpdesk_mgmt/data/helpdesk_data.xml
@@ -278,6 +278,7 @@
             <field name="name">Done</field>
             <field name="unattended">False</field>
             <field name="closed">True</field>
+            <field name="close_from_portal">True</field>
             <field name="fold">True</field>
             <field name="mail_template_id" ref="helpdesk_mgmt.closed_ticket_template" />
             <field name="company_id" />
@@ -287,6 +288,17 @@
             <field name="name">Cancelled</field>
             <field name="unattended">False</field>
             <field name="closed">True</field>
+            <field name="close_from_portal">True</field>
+            <field name="fold">True</field>
+            <field name="mail_template_id" ref="helpdesk_mgmt.closed_ticket_template" />
+            <field name="company_id" />
+        </record>
+        <record id="helpdesk_ticket_stage_rejected" model="helpdesk.ticket.stage">
+            <field name="sequence">6</field>
+            <field name="name">Rejected</field>
+            <field name="unattended">False</field>
+            <field name="closed">True</field>
+            <field name="close_from_portal">False</field>
             <field name="fold">True</field>
             <field name="mail_template_id" ref="helpdesk_mgmt.closed_ticket_template" />
             <field name="company_id" />

--- a/helpdesk_mgmt/models/helpdesk_ticket_stage.py
+++ b/helpdesk_mgmt/models/helpdesk_ticket_stage.py
@@ -1,4 +1,4 @@
-from odoo import fields, models
+from odoo import api, fields, models
 
 
 class HelpdeskTicketStage(models.Model):
@@ -12,6 +12,10 @@ class HelpdeskTicketStage(models.Model):
     active = fields.Boolean(default=True)
     unattended = fields.Boolean()
     closed = fields.Boolean()
+    close_from_portal = fields.Boolean(
+        help="Display button in portal ticket form to allow closing ticket "
+        "with this stage as target."
+    )
     mail_template_id = fields.Many2one(
         comodel_name="mail.template",
         string="Email Template",
@@ -31,3 +35,8 @@ class HelpdeskTicketStage(models.Model):
         string="Company",
         default=lambda self: self.env.company,
     )
+
+    @api.onchange("closed")
+    def _onchange_closed(self):
+        if not self.closed:
+            self.close_from_portal = False

--- a/helpdesk_mgmt/readme/ROADMAP.rst
+++ b/helpdesk_mgmt/readme/ROADMAP.rst
@@ -1,4 +1,3 @@
 * Add a tour feature similar to what the ``project`` module defines to discover projects / tasks.
 * Update portal tests defined in ``tests/test_portal.py`` to rely on tour specs (in JS)
   in order to replicate the navigation behavior of portal users.
-* Portal tests: Test close buttons available in portal ticket forms.

--- a/helpdesk_mgmt/views/helpdesk_ticket_stage_views.xml
+++ b/helpdesk_mgmt/views/helpdesk_ticket_stage_views.xml
@@ -54,6 +54,10 @@
                         </group>
                         <group name="main_right">
                             <field name="closed" />
+                            <field
+                                name="close_from_portal"
+                                attrs="{'invisible': [('closed', '=', False)]}"
+                            />
                             <field name="unattended" />
                         </group>
                     </group>


### PR DESCRIPTION
By default portal users can close tickets they have submitted; close buttons available to them are all ticket stages marked as "closed".
This PR gives finer control on which stages portal users may switch to when closing a ticket.
Typical use case: a "declined by customer support" stage that marks the ticket as closed but should not be available to portal users.

* Add tests around close buttons available in portal forms + a guard against invalid stage request in the controller
* Add a setting in ticket stage configuration to control which close buttons are available in portal mode:
    * Ticket stage: Add a "close from portal" setting.
    * Portal form: Display ticket close buttons according to that setting.
    * Default stages: Add a "rejected" closed stage unavailable to portal.

Stage config with new setting:
![Screenshot at 2022-11-17 11-52-16](https://user-images.githubusercontent.com/6347423/202429670-ae2e650f-77d1-48c6-953f-1f3c1f3dc99d.png)

Close buttons ("terminé" & "annulé" in French) are now displayed based on that setting:
![Screenshot at 2022-11-17 11-52-33](https://user-images.githubusercontent.com/6347423/202429816-8723a6bf-b533-43a9-a0c8-19cbbbbce903.png)
