### PR TITLE
[14.0][FIX] helpdesk_mgmt: assigned date empty and creation method to multi

### DIFF
--- a/helpdesk_mgmt/models/helpdesk_ticket.py
+++ b/helpdesk_mgmt/models/helpdesk_ticket.py
@@ -134,6 +134,8 @@ class HelpdeskTicket(models.Model):
             vals["number"] = self._prepare_ticket_number(vals)
         if not vals.get("team_id") and vals.get("category_id"):
             vals["team_id"] = self._prepare_team_id(vals)
+        if vals.get("user_id") and not vals.get("assigned_date"):
+            vals["assigned_date"] = fields.Datetime.now()
         return super().create(vals)
 
     def copy(self, default=None):

--- a/helpdesk_mgmt/models/helpdesk_ticket.py
+++ b/helpdesk_mgmt/models/helpdesk_ticket.py
@@ -128,15 +128,16 @@ class HelpdeskTicket(models.Model):
     def _creation_subtype(self):
         return self.env.ref("helpdesk_mgmt.hlp_tck_created")
 
-    @api.model
-    def create(self, vals):
-        if vals.get("number", "/") == "/":
-            vals["number"] = self._prepare_ticket_number(vals)
-        if not vals.get("team_id") and vals.get("category_id"):
-            vals["team_id"] = self._prepare_team_id(vals)
-        if vals.get("user_id") and not vals.get("assigned_date"):
-            vals["assigned_date"] = fields.Datetime.now()
-        return super().create(vals)
+    @api.model_create_multi
+    def create(self, vals_list):
+        for vals in vals_list:
+            if vals.get("number", "/") == "/":
+                vals["number"] = self._prepare_ticket_number(vals)
+            if not vals.get("team_id") and vals.get("category_id"):
+                vals["team_id"] = self._prepare_team_id(vals)
+            if vals.get("user_id") and not vals.get("assigned_date"):
+                vals["assigned_date"] = fields.Datetime.now()
+        return super().create(vals_list)
 
     def copy(self, default=None):
         self.ensure_one()


### PR DESCRIPTION
When creating a new ticket with an assigned user, the assigned date field was being left empty. Now when the user is being assigned in the creation, the assigned date is settled with creation_date.
Also changed the create function from @api.model to @api.model_create_multi.

@ForgeFlow