### PR TITLE
[14.0][IMP] helpdesk_mgmt_project: link kanban task with tickets

### DIFF
--- a/helpdesk_mgmt_project/models/project_task.py
+++ b/helpdesk_mgmt_project/models/project_task.py
@@ -27,3 +27,30 @@ class ProjectTask(models.Model):
             record.todo_ticket_count = len(
                 record.ticket_ids.filtered(lambda ticket: not ticket.closed)
             )
+
+    def action_view_ticket(self):
+        result = self.env["ir.actions.act_window"]._for_xml_id(
+            "helpdesk_mgmt.action_helpdesk_ticket_kanban_from_dashboard"
+        )
+        # choose the view_mode accordingly
+        if not self.ticket_ids or len(self.ticket_ids) > 1:
+            result["domain"] = "[('id','in',%s)]" % (self.ticket_ids.ids)
+            res = self.env.ref("helpdesk_mgmt.ticket_view_tree", False)
+            tree_view = [(res and res.id or False, "tree")]
+            if "views" in result:
+                result["views"] = tree_view + [
+                    (state, view) for state, view in result["views"] if view != "tree"
+                ]
+            else:
+                result["views"] = tree_view
+        elif len(self.ticket_ids) == 1:
+            res = self.env.ref("helpdesk_mgmt.ticket_view_form", False)
+            form_view = [(res and res.id or False, "form")]
+            if "views" in result:
+                result["views"] = form_view + [
+                    (state, view) for state, view in result["views"] if view != "form"
+                ]
+            else:
+                result["views"] = form_view
+            result["res_id"] = self.ticket_ids.id
+        return result

--- a/helpdesk_mgmt_project/views/project_task_view.xml
+++ b/helpdesk_mgmt_project/views/project_task_view.xml
@@ -30,4 +30,29 @@
             </xpath>
         </field>
     </record>
+    <record id="view_task_kanban_helpdesk" model="ir.ui.view">
+        <field name="model">project.task</field>
+        <field name="inherit_id" ref="project.view_task_kanban" />
+        <field name="arch" type="xml">
+             <div class="oe_kanban_bottom_right" position="before">
+                <div attrs="{'invisible':[('ticket_count', '=', 0)]}">
+                    <a
+                        class="o_project_kanban_box"
+                        name="action_view_ticket"
+                        type="object"
+                    >
+                        <span class="o_value">
+                            <b>
+                                <field name="ticket_count" />
+                            </b>
+                        </span>
+                        <span class="o_label">
+                          <field name="label_tickets" />
+                        </span>
+                    </a>
+                    &#160;
+                </div>
+            </div>
+        </field>
+    </record>
 </odoo>


### PR DESCRIPTION
When checking multiple ticket related to a multiple tasks, sometimes entering to the Form view to check the related tickets may be slow. With this the number of tickets and a link to them is visible from the kanban view.

@ForgeFlow