### PR TITLE
[14.0][IMP] helpdesk_mgmt: Only show tickets of the user's helpdesk team with "User: Team tickets" permission.

### DIFF
--- a/helpdesk_mgmt/__manifest__.py
+++ b/helpdesk_mgmt/__manifest__.py
@@ -4,7 +4,7 @@
     "name": "Helpdesk Management",
     "summary": """
         Helpdesk""",
-    "version": "14.0.2.0.2",
+    "version": "14.0.2.1.0",
     "license": "AGPL-3",
     "category": "After-Sales",
     "author": "AdaptiveCity, "

--- a/helpdesk_mgmt/migrations/14.0.2.1.0/noupdate_changes.xml
+++ b/helpdesk_mgmt/migrations/14.0.2.1.0/noupdate_changes.xml
@@ -1,0 +1,8 @@
+<?xml version='1.0' encoding='utf-8' ?>
+<odoo>
+    <record id="helpdesk_ticket_personal_rule" model="ir.rule">
+        <field
+            name="domain_force"
+        >["|", ('user_id', '=', user.id), '&amp;', ('user_id','=',False), ('team_id', 'in', user.helpdesk_team_ids.ids)]</field>
+    </record>
+</odoo>

--- a/helpdesk_mgmt/migrations/14.0.2.1.0/post-migration.py
+++ b/helpdesk_mgmt/migrations/14.0.2.1.0/post-migration.py
@@ -1,0 +1,11 @@
+# Copyright 2023 Tecnativa - Víctor Martínez
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    openupgrade.load_data(
+        env.cr, "helpdesk_mgmt", "migrations/14.0.2.1.0/noupdate_changes.xml"
+    )

--- a/helpdesk_mgmt/security/helpdesk_security.xml
+++ b/helpdesk_mgmt/security/helpdesk_security.xml
@@ -32,7 +32,7 @@
             <field ref="model_helpdesk_ticket" name="model_id" />
             <field
                 name="domain_force"
-            >['|',('user_id','=',user.id),('user_id','=',False)]</field>
+            >["|", ('user_id', '=', user.id), '&amp;', ('user_id','=',False), ('team_id', 'in', user.helpdesk_team_ids.ids)]</field>
             <field name="groups" eval="[(4, ref('group_helpdesk_user_own'))]" />
         </record>
         <record id="helpdesk_ticket_team_rule" model="ir.rule">

--- a/helpdesk_mgmt/tests/common.py
+++ b/helpdesk_mgmt/tests/common.py
@@ -1,0 +1,60 @@
+# Copyright 2023 Tecnativa - Víctor Martínez
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+from odoo.tests import common, new_test_user
+
+
+class TestHelpdeskTicketBase(common.SavepointCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        helpdesk_ticket_team = cls.env["helpdesk.ticket.team"]
+        ctx = {
+            "mail_create_nolog": True,
+            "mail_create_nosubscribe": True,
+            "mail_notrack": True,
+            "no_reset_password": True,
+        }
+        cls.user_own = new_test_user(
+            cls.env,
+            login="helpdesk_mgmt-user_own",
+            groups="helpdesk_mgmt.group_helpdesk_user_own",
+            context=ctx,
+        )
+        cls.user_team = new_test_user(
+            cls.env,
+            login="helpdesk_mgmt-user_team",
+            groups="helpdesk_mgmt.group_helpdesk_user_team",
+            context=ctx,
+        )
+        cls.user = new_test_user(
+            cls.env,
+            login="helpdesk_mgmt-user",
+            groups="helpdesk_mgmt.group_helpdesk_user",
+            context=ctx,
+        )
+        cls.stage_closed = cls.env.ref("helpdesk_mgmt.helpdesk_ticket_stage_done")
+        cls.team_a = helpdesk_ticket_team.create(
+            {"name": "Team A", "user_ids": [(6, 0, [cls.user_own.id, cls.user.id])]}
+        )
+        cls.team_b = helpdesk_ticket_team.create(
+            {"name": "Team B", "user_ids": [(6, 0, [cls.user_team.id])]}
+        )
+        cls.ticket_a_unassigned = cls._create_ticket(cls, cls.team_a)
+        cls.ticket_a_unassigned.priority = "3"
+        cls.ticket_a_user_own = cls._create_ticket(cls, cls.team_a, cls.user_own)
+        cls.ticket_a_user_team = cls._create_ticket(cls, cls.team_a, cls.user_team)
+        cls.ticket_b_unassigned = cls._create_ticket(cls, cls.team_b)
+        cls.ticket_b_user_own = cls._create_ticket(cls, cls.team_b, cls.user_own)
+        cls.ticket_b_user_team = cls._create_ticket(cls, cls.team_b, cls.user_team)
+
+    def _create_ticket(self, team, user=False):
+        return self.env["helpdesk.ticket"].create(
+            {
+                "name": "Ticket %s (%s)"
+                % (team.name, user.login if user else "unassigned"),
+                "description": "Description",
+                "team_id": team.id,
+                "user_id": user.id if user else False,
+                "priority": "1",
+            }
+        )

--- a/helpdesk_mgmt/tests/test_helpdesk_ticket.py
+++ b/helpdesk_mgmt/tests/test_helpdesk_ticket.py
@@ -1,41 +1,29 @@
 import time
 
-from odoo.tests import common
+from .common import TestHelpdeskTicketBase
 
 
-class TestHelpdeskTicket(common.SavepointCase):
+class TestHelpdeskTicket(TestHelpdeskTicketBase):
     @classmethod
     def setUpClass(cls):
-        super(TestHelpdeskTicket, cls).setUpClass()
-        helpdesk_ticket = cls.env["helpdesk.ticket"]
-        cls.user_admin = cls.env.ref("base.user_root")
-        cls.user_demo = cls.env.ref("base.user_demo")
-        cls.stage_closed = cls.env.ref("helpdesk_mgmt.helpdesk_ticket_stage_done")
-
-        cls.ticket = helpdesk_ticket.create(
-            {"name": "Test 1", "description": "Ticket test"}
-        )
+        super().setUpClass()
+        cls.ticket = cls.ticket_a_unassigned
 
     def test_helpdesk_ticket_datetimes(self):
         old_stage_update = self.ticket.last_stage_update
-
         self.assertTrue(
             self.ticket.last_stage_update,
             "Helpdesk Ticket: Helpdesk ticket should "
             "have a last_stage_update at all times.",
         )
-
         self.assertFalse(
             self.ticket.closed_date,
             "Helpdesk Ticket: No closed date "
             "should be set for a non closed "
             "ticket.",
         )
-
         time.sleep(1)
-
         self.ticket.write({"stage_id": self.stage_closed.id})
-
         self.assertTrue(
             self.ticket.closed_date,
             "Helpdesk Ticket: A closed ticket " "should have a closed_date value.",
@@ -46,8 +34,7 @@ class TestHelpdeskTicket(common.SavepointCase):
             "should be updated at every stage_id "
             "change.",
         )
-
-        self.ticket.write({"user_id": self.user_admin.id})
+        self.ticket.write({"user_id": self.user.id})
         self.assertTrue(
             self.ticket.assigned_date,
             "Helpdesk Ticket: An assigned ticket " "should contain a assigned_date.",
@@ -65,9 +52,7 @@ class TestHelpdeskTicket(common.SavepointCase):
 
     def test_helpdesk_ticket_copy(self):
         old_ticket_number = self.ticket.number
-
         copy_ticket_number = self.ticket.copy().number
-
         self.assertTrue(
             copy_ticket_number != "/" and old_ticket_number != copy_ticket_number,
             "Helpdesk Ticket: A new ticket can not "

--- a/helpdesk_mgmt/tests/test_helpdesk_ticket_team.py
+++ b/helpdesk_mgmt/tests/test_helpdesk_ticket_team.py
@@ -1,88 +1,83 @@
-from odoo.tests import common
+# Copyright 2023 Tecnativa - Víctor Martínez
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+from odoo.tests.common import users
+
+from .common import TestHelpdeskTicketBase
 
 
-class TestHelpdeskTicketTeam(common.SavepointCase):
-    @classmethod
-    def setUpClass(cls):
-        super(TestHelpdeskTicketTeam, cls).setUpClass()
-        helpdesk_ticket = cls.env["helpdesk.ticket"]
-        helpdesk_ticket_team = cls.env["helpdesk.ticket.team"]
-        mail_alias = cls.env["mail.alias"]
-        cls.user_demo = cls.env.ref("base.user_demo")
-        cls.stage_closed = cls.env.ref("helpdesk_mgmt.helpdesk_ticket_stage_done")
-        cls.mail_alias_id = mail_alias.create(
-            {
-                "alias_name": "Test Mail Alias",
-                "alias_model_id": cls.env["ir.model"]
-                .search([("model", "=", "helpdesk.ticket")])
-                .id,
-            }
-        )
-        cls.team_id = helpdesk_ticket_team.create(
-            {"name": "Team 1", "alias_id": cls.mail_alias_id.id}
-        )
-        cls.helpdesk_ticket_1 = helpdesk_ticket.create(
-            {
-                "name": "Ticket 1",
-                "description": "Description",
-                "team_id": cls.team_id.id,
-                "priority": "3",
-            }
-        )
-        cls.helpdesk_ticket_2 = helpdesk_ticket.create(
-            {
-                "name": "Ticket 2",
-                "description": "Description",
-                "team_id": cls.team_id.id,
-                "user_id": cls.user_demo.id,
-                "priority": "1",
-            }
-        )
+class TestHelpdeskTicketTeam(TestHelpdeskTicketBase):
+    @users("helpdesk_mgmt-user_own")
+    def test_helpdesk_ticket_user_own(self):
+        tickets = self.env["helpdesk.ticket"].search([])
+        self.assertIn(self.ticket_a_unassigned, tickets)
+        self.assertIn(self.ticket_a_user_own, tickets)
+        self.assertNotIn(self.ticket_a_user_team, tickets)
+        self.assertNotIn(self.ticket_b_unassigned, tickets)
+        self.assertIn(self.ticket_b_user_own, tickets)
+        self.assertNotIn(self.ticket_b_user_team, tickets)
+
+    @users("helpdesk_mgmt-user_team")
+    def test_helpdesk_ticket_user_team(self):
+        tickets = self.env["helpdesk.ticket"].search([])
+        self.assertNotIn(self.ticket_a_unassigned, tickets)
+        self.assertNotIn(self.ticket_a_user_own, tickets)
+        self.assertIn(self.ticket_a_user_team, tickets)
+        self.assertIn(self.ticket_b_unassigned, tickets)
+        self.assertIn(self.ticket_b_user_own, tickets)
+        self.assertIn(self.ticket_b_user_team, tickets)
+
+    @users("helpdesk_mgmt-user")
+    def test_helpdesk_ticket_user(self):
+        tickets = self.env["helpdesk.ticket"].search([])
+        self.assertIn(self.ticket_a_unassigned, tickets)
+        self.assertIn(self.ticket_a_user_own, tickets)
+        self.assertIn(self.ticket_a_user_team, tickets)
+        self.assertIn(self.ticket_b_unassigned, tickets)
+        self.assertIn(self.ticket_b_user_own, tickets)
+        self.assertIn(self.ticket_b_user_team, tickets)
 
     def test_helpdesk_ticket_todo(self):
         self.assertEqual(
-            self.team_id.todo_ticket_count,
-            2,
-            "Helpdesk Ticket: Helpdesk ticket team should " "have two tickets to do.",
+            self.team_a.todo_ticket_count,
+            3,
+            "Helpdesk Ticket: Helpdesk ticket team should have three tickets to do.",
         )
         self.assertEqual(
-            self.team_id.todo_ticket_count_unassigned,
+            self.team_a.todo_ticket_count_unassigned,
             1,
             "Helpdesk Ticket: Helpdesk ticket team should "
             "have one tickets unassigned.",
         )
         self.assertEqual(
-            self.team_id.todo_ticket_count_high_priority,
+            self.team_a.todo_ticket_count_high_priority,
             1,
             "Helpdesk Ticket: Helpdesk ticket team should "
-            "have two tickets with high priority.",
+            "have one ticket with high priority.",
         )
         self.assertEqual(
-            self.team_id.todo_ticket_count_unattended,
+            self.team_a.todo_ticket_count_unattended,
+            3,
+            "Helpdesk Ticket: Helpdesk ticket team should "
+            "have three tickets unattended.",
+        )
+
+        self.ticket_a_unassigned.write({"stage_id": self.stage_closed.id})
+        self.assertEqual(
+            self.team_a.todo_ticket_count_unattended,
             2,
             "Helpdesk Ticket: Helpdesk ticket team should "
             "have two tickets unattended.",
         )
-
-        self.helpdesk_ticket_1.write({"stage_id": self.stage_closed.id})
-
         self.assertEqual(
-            self.team_id.todo_ticket_count_unattended,
-            1,
-            "Helpdesk Ticket: Helpdesk ticket team should "
-            "have one ticket unattended.",
-        )
-
-        self.assertEqual(
-            self.team_id.todo_ticket_count,
-            1,
-            "Helpdesk Ticket: Helpdesk ticket team should " "have one ticket to do.",
+            self.team_a.todo_ticket_count,
+            2,
+            "Helpdesk Ticket: Helpdesk ticket team should have two ticket to do.",
         )
 
     def test_helpdesk_ticket_team_from_category(self):
         self.assertEqual(
-            self.team_id.todo_ticket_count,
-            2,
+            self.team_a.todo_ticket_count,
+            3,
         )
         category = self.env.ref("helpdesk_mgmt.helpdesk_category_1")
         self.env["helpdesk.ticket"].create(
@@ -93,10 +88,10 @@ class TestHelpdeskTicketTeam(common.SavepointCase):
             }
         )
         self.assertEqual(
-            self.team_id.todo_ticket_count,
-            2,
+            self.team_a.todo_ticket_count,
+            3,
         )
-        category.default_team_id = self.team_id
+        category.default_team_id = self.team_a
         self.env["helpdesk.ticket"].create(
             {
                 "name": "Ticket 1",
@@ -105,6 +100,6 @@ class TestHelpdeskTicketTeam(common.SavepointCase):
             }
         )
         self.assertEqual(
-            self.team_id.todo_ticket_count,
-            3,
+            self.team_a.todo_ticket_count,
+            4,
         )

--- a/helpdesk_mgmt/tests/test_res_partner.py
+++ b/helpdesk_mgmt/tests/test_res_partner.py
@@ -3,7 +3,7 @@ from odoo.tests.common import SavepointCase
 
 class TestPartner(SavepointCase):
     def setUp(self):
-        super(TestPartner, self).setUp()
+        super().setUp()
         self.partner_obj = self.env["res.partner"]
         self.ticket_obj = self.env["helpdesk.ticket"]
         self.stage_id_closed = self.env.ref("helpdesk_mgmt.helpdesk_ticket_stage_done")
@@ -39,5 +39,4 @@ class TestPartner(SavepointCase):
         self.assertEqual(self.parent_id.helpdesk_ticket_active_count, 3)
 
     def test_ticket_string(self):
-
         self.assertEqual(self.parent_id.helpdesk_ticket_count_string, "3 / 4")

--- a/helpdesk_mgmt_project/tests/test_helpdesk_ticket.py
+++ b/helpdesk_mgmt_project/tests/test_helpdesk_ticket.py
@@ -4,11 +4,10 @@ from odoo.addons.helpdesk_mgmt.tests import test_helpdesk_ticket
 class TestHelpdeskTicketProject(test_helpdesk_ticket.TestHelpdeskTicket):
     @classmethod
     def setUpClass(cls):
-        super(TestHelpdeskTicketProject, cls).setUpClass()
-        env = cls.env(user=cls.user_admin)
-        Ticket = env["helpdesk.ticket"]
-        Project = env["project.project"]
-        Task = env["project.task"]
+        super().setUpClass()
+        Ticket = cls.env["helpdesk.ticket"]
+        Project = cls.env["project.project"]
+        Task = cls.env["project.task"]
         cls.ticket2 = Ticket.create({"name": "Test 2", "description": "Ticket test2"})
         cls.project1 = Project.create({"name": "Test Helpdesk-Project 1"})
         cls.task_project1 = Task.create(


### PR DESCRIPTION
FWP from 13.0: https://github.com/OCA/helpdesk/pull/416

Only show tickets of the user's helpdesk team with "`User: Team tickets`" permission (related to https://github.com/OCA/helpdesk/pull/395#pullrequestreview-1229370921)

Please @pedrobaeza and @chienandalu can you review it?

@Tecnativa TT41172