### PR TITLE
[15.0][IMP] helpdesk_mgmt: Add sequence field to category, channel and team objects

### DIFF
--- a/helpdesk_mgmt/models/helpdesk_ticket_category.py
+++ b/helpdesk_mgmt/models/helpdesk_ticket_category.py
@@ -5,7 +5,9 @@ class HelpdeskCategory(models.Model):
 
     _name = "helpdesk.ticket.category"
     _description = "Helpdesk Ticket Category"
+    _order = "sequence, id"
 
+    sequence = fields.Integer(default=10)
     active = fields.Boolean(
         default=True,
     )

--- a/helpdesk_mgmt/models/helpdesk_ticket_channel.py
+++ b/helpdesk_mgmt/models/helpdesk_ticket_channel.py
@@ -5,7 +5,9 @@ class HelpdeskTicketChannel(models.Model):
 
     _name = "helpdesk.ticket.channel"
     _description = "Helpdesk Ticket Channel"
+    _order = "sequence, id"
 
+    sequence = fields.Integer(default=10)
     name = fields.Char(required=True)
     active = fields.Boolean(default=True)
     company_id = fields.Many2one(

--- a/helpdesk_mgmt/models/helpdesk_ticket_team.py
+++ b/helpdesk_mgmt/models/helpdesk_ticket_team.py
@@ -7,7 +7,9 @@ class HelpdeskTeam(models.Model):
     _name = "helpdesk.ticket.team"
     _description = "Helpdesk Ticket Team"
     _inherit = ["mail.thread", "mail.alias.mixin"]
+    _order = "sequence, id"
 
+    sequence = fields.Integer(default=10)
     name = fields.Char(required=True)
     user_ids = fields.Many2many(
         comodel_name="res.users",

--- a/helpdesk_mgmt/views/helpdesk_ticket_category_views.xml
+++ b/helpdesk_mgmt/views/helpdesk_ticket_category_views.xml
@@ -55,6 +55,7 @@
         <field name="model">helpdesk.ticket.category</field>
         <field name="arch" type="xml">
             <tree>
+                <field name="sequence" widget="handle" />
                 <field name="name" />
             </tree>
         </field>

--- a/helpdesk_mgmt/views/helpdesk_ticket_channel_views.xml
+++ b/helpdesk_mgmt/views/helpdesk_ticket_channel_views.xml
@@ -55,6 +55,7 @@
         <field name="model">helpdesk.ticket.channel</field>
         <field name="arch" type="xml">
             <tree>
+                <field name="sequence" widget="handle" />
                 <field name="name" />
             </tree>
         </field>

--- a/helpdesk_mgmt/views/helpdesk_ticket_team_views.xml
+++ b/helpdesk_mgmt/views/helpdesk_ticket_team_views.xml
@@ -148,6 +148,7 @@
         <field name="model">helpdesk.ticket.team</field>
         <field name="arch" type="xml">
             <tree>
+                <field name="sequence" widget="handle" />
                 <field name="name" />
                 <field name="category_ids" widget="many2many_tags" />
                 <field name="todo_ticket_count" string="Active tickets" />


### PR DESCRIPTION
FWP from 14.0: https://github.com/OCA/helpdesk/pull/422

Add `sequence` field to category, channel and team objects.

Please @pedrobaeza and @chienandalu can you review it?

@Tecnativa TT41245