### PR TITLE
[13.0][FIX] helpdesk_motive: onchange removed in base module

### DIFF
--- a/helpdesk_motive/models/helpdesk_ticket.py
+++ b/helpdesk_motive/models/helpdesk_ticket.py
@@ -12,7 +12,6 @@ class HelpdeskTicket(models.Model):
     )
 
     @api.onchange("team_id", "user_id")
-    def _onchange_dominion_user_id(self):
-        super()._onchange_dominion_user_id()
+    def _onchange_team_user_helpdesk_motive(self):
         for record in self:
             record.motive_id = False


### PR DESCRIPTION
Fix like https://github.com/OCA/helpdesk/pull/417

_onchange_dominion_user_id has been removed in helpdesk_mgmt, so it cannot be extended anymore in helpdesk_motive.