### PR TITLE
[14.0][FIX] helpdesk_mgmt: Preserve line breaks on tickets submitted from the portal

### DIFF
--- a/helpdesk_mgmt/controllers/main.py
+++ b/helpdesk_mgmt/controllers/main.py
@@ -5,6 +5,7 @@ import werkzeug
 
 import odoo.http as http
 from odoo.http import request
+from odoo.tools import plaintext2html
 
 _logger = logging.getLogger(__name__)
 
@@ -62,7 +63,7 @@ class HelpdeskTicketController(http.Controller):
         vals = {
             "company_id": company.id,
             "category_id": category.id,
-            "description": kw.get("description"),
+            "description": plaintext2html(kw.get("description")),
             "name": kw.get("subject"),
             "attachment_ids": False,
             "channel_id": request.env["helpdesk.ticket.channel"]

--- a/helpdesk_mgmt/tests/test_helpdesk_portal.py
+++ b/helpdesk_mgmt/tests/test_helpdesk_portal.py
@@ -77,6 +77,10 @@ class TestHelpdeskPortal(odoo.tests.HttpCase):
         tickets = self.get_new_tickets(self.basic_user)
         self.assertNotIn(self.portal_ticket, tickets)
         self.assertIn(self.new_ticket_title, tickets.mapped("name"))
+        self.assertIn(
+            "<p>" + "<br>".join(self.new_ticket_desc_lines) + "</p>",
+            tickets.mapped("description"),
+        )
 
     def test_submit_ticket_02(self):
         self.authenticate("test-portal", "test-portal")
@@ -84,3 +88,7 @@ class TestHelpdeskPortal(odoo.tests.HttpCase):
         tickets = self.get_new_tickets(self.portal_user)
         self.assertIn(self.portal_ticket, tickets)
         self.assertIn(self.new_ticket_title, tickets.mapped("name"))
+        self.assertIn(
+            "<p>" + "<br>".join(self.new_ticket_desc_lines) + "</p>",
+            tickets.mapped("description"),
+        )


### PR DESCRIPTION
Backport from 15.0: https://github.com/OCA/helpdesk/pull/379

Preserve line breaks on tickets submitted from the portal

Rely on `plaintext2html`, same as Odoo in its controller for message threads (`/odoo15/addons/portal/controllers/mail.py`).

Existing portal test adapted to check this.

Please @pedrobaeza and @chienandalu can you review it?

@Tecnativa