### PR TITLE
[14.0][FIX] helpdesk_mgmt: Correctly display description field in portal page

### DIFF
--- a/helpdesk_mgmt/views/helpdesk_ticket_templates.xml
+++ b/helpdesk_mgmt/views/helpdesk_ticket_templates.xml
@@ -165,8 +165,8 @@
                     </div>
                     <div class="panel-body">
                         <div class="mb8">
-                            <div>
-                                <div class="pull-left">
+                            <div class="row">
+                                <div class="col-md-6">
                                     <strong>Number:</strong>
                                     <span t-field="ticket.number" />
                                     <br />
@@ -180,7 +180,7 @@
                                     <t t-esc="ticket.stage_id.name" />
                                     <br />
                                 </div>
-                                <div class="pull-right">
+                                <div class="col-md-6">
                                     <strong>Last Stage Update:</strong>
                                     <span t-field="ticket.last_stage_update" />
                                     <br />


### PR DESCRIPTION
FWP from 13.0: https://github.com/OCA/helpdesk/pull/457

Correctly display description field in portal page

**Before**
![antes](https://user-images.githubusercontent.com/4117568/234902690-dda53633-dc58-4b74-be39-210f437d6b0e.png)

**After**
![despues](https://user-images.githubusercontent.com/4117568/234902713-dbc36b52-cff0-427e-b093-9ea85d58062f.png)

@Tecnativa TT42817