### PR TITLE
[15.0][FIX] helpdesk_mgmt: portal view

### DIFF
--- a/helpdesk_mgmt/views/helpdesk_ticket_templates.xml
+++ b/helpdesk_mgmt/views/helpdesk_ticket_templates.xml
@@ -121,7 +121,7 @@
                         <t t-foreach="tickets" t-as="ticket">
                             <tr>
                                 <td class="text-left">
-                                    <span t-esc="ticket.partner_id.name" />
+                                    <span t-field="ticket.partner_id" />
                                 </td>
                                 <td class="text-left">
                                     <span t-esc="ticket.number" />


### PR DESCRIPTION
fw of #461 
Portal users can't access to partner's records data so if a users partner is subscribed to another partner ticket we'll get an access error whenever the user tries to get into the portal. We can use in this case the t-field directive to show the info.

cc @Tecnativa TT42618

ping @victoralmau @pedrobaeza 