### PR TITLE
[14.0][FW-PORT] helpdesk_mgmt: Better attachments support

### DIFF
--- a/helpdesk_mgmt/controllers/main.py
+++ b/helpdesk_mgmt/controllers/main.py
@@ -91,10 +91,12 @@ class HelpdeskTicketController(http.Controller):
         new_ticket = request.env["helpdesk.ticket"].sudo().create(vals)
         new_ticket.message_subscribe(partner_ids=request.env.user.partner_id.ids)
         if kw.get("attachment"):
+            IrAttachment = request.env["ir.attachment"]
+            attachment_ids = IrAttachment
             for c_file in request.httprequest.files.getlist("attachment"):
                 data = c_file.read()
                 if c_file.filename:
-                    request.env["ir.attachment"].sudo().create(
+                    attachment_ids += IrAttachment.sudo().create(
                         {
                             "name": c_file.filename,
                             "datas": base64.b64encode(data),
@@ -102,4 +104,5 @@ class HelpdeskTicketController(http.Controller):
                             "res_id": new_ticket.id,
                         }
                     )
+            attachment_ids.sudo().generate_access_token()
         return werkzeug.utils.redirect("/my/ticket/%s" % new_ticket.id)

--- a/helpdesk_mgmt/controllers/myaccount.py
+++ b/helpdesk_mgmt/controllers/myaccount.py
@@ -113,10 +113,21 @@ class CustomerPortalHelpdesk(CustomerPortal):
         closed_stages = request.env["helpdesk.ticket.stage"].search(
             [("closed", "=", True)]
         )
+        files = (
+            request.env["ir.attachment"]
+            .sudo()
+            .search(
+                [
+                    ("res_model", "=", "helpdesk.ticket"),
+                    ("res_id", "=", ticket.id),
+                ]
+            )
+        )
         values = {
             "page_name": "ticket",
             "ticket": ticket,
             "closed_stages": closed_stages,
+            "files": files,
         }
 
         if kwargs.get("error"):

--- a/helpdesk_mgmt/tests/test_helpdesk_portal.py
+++ b/helpdesk_mgmt/tests/test_helpdesk_portal.py
@@ -58,7 +58,7 @@ class TestHelpdeskPortalBase(odoo.tests.HttpCase):
         data.update(**values)
         return self.env["helpdesk.ticket"].create(data)
 
-    def _submit_ticket(self, **values):
+    def _submit_ticket(self, files=None, **values):
         data = {
             "category": self.env.ref("helpdesk_mgmt.helpdesk_category_1").id,
             "csrf_token": http.WebRequest.csrf_token(self),
@@ -66,7 +66,7 @@ class TestHelpdeskPortalBase(odoo.tests.HttpCase):
             "description": "\n".join(self.new_ticket_desc_lines),
         }
         data.update(**values)
-        resp = self.url_open("/submitted/ticket", data=data)
+        resp = self.url_open("/submitted/ticket", data=data, files=files)
         self.assertEqual(resp.status_code, 200)
 
 
@@ -93,3 +93,34 @@ class TestHelpdeskPortal(TestHelpdeskPortalBase):
             "<p>" + "<br>".join(self.new_ticket_desc_lines) + "</p>",
             tickets.mapped("description"),
         )
+
+    def test_submit_ticket_with_attachments(self):
+        self.authenticate("test-user", "test-user")
+        self._submit_ticket(
+            files=[
+                (
+                    "attachment",
+                    ("test.txt", b"test", "plain/text"),
+                ),
+                (
+                    "attachment",
+                    ("test.svg", b"<svg></svg>", "image/svg+xml"),
+                ),
+            ]
+        )
+        ticket_id = self.get_new_tickets(self.basic_user)
+        self.assertEqual(len(ticket_id), 1)
+        # check that both files have been linked to the newly created ticket
+        attachment_ids = self.env["ir.attachment"].search(
+            [
+                ("res_model", "=", "helpdesk.ticket"),
+                ("res_id", "=", ticket_id.id),
+            ]
+        )
+        self.assertEqual(len(attachment_ids), 2)
+        # check that both files have kept their names
+        self.assertIn("test.txt", attachment_ids.mapped("name"))
+        self.assertIn("test.svg", attachment_ids.mapped("name"))
+        # check that both files are public (access_token is set)
+        self.assertTrue(attachment_ids[0].access_token)
+        self.assertTrue(attachment_ids[1].access_token)

--- a/helpdesk_mgmt/views/helpdesk_ticket_templates.xml
+++ b/helpdesk_mgmt/views/helpdesk_ticket_templates.xml
@@ -298,15 +298,13 @@
                         for="attachment"
                     >Add Attachments</label>
                     <div class="col-md-7 col-sm-8">
-                        <div class="btn btn-default btn-file col-md-12">
                             <input
-                                class="form-control o_website_form_input"
-                                name="attachment"
-                                id="attachment"
-                                type="file"
-                                multiple="multiple"
-                            />
-                        </div>
+                            class="form-control o_website_form_input"
+                            name="attachment"
+                            id="attachment"
+                            type="file"
+                            multiple="multiple"
+                        />
                     </div>
                 </div>
                 <div class="form-group">

--- a/helpdesk_mgmt/views/helpdesk_ticket_templates.xml
+++ b/helpdesk_mgmt/views/helpdesk_ticket_templates.xml
@@ -54,14 +54,14 @@
             <t t-set="breadcrumbs_searchbar" t-value="True" />
             <form method="POST" t-attf-action="/new/ticket">
                 <h3>Tickets
-            <t t-call="portal.portal_searchbar" />
-            <button
+                    <t t-call="portal.portal_searchbar" />
+                    <button
                         name="create_new_ticket"
                         type="action"
                         class="btn btn-primary"
                         style="float: right; margin-right: 5px;"
                     >New Ticket</button>
-          </h3>
+                </h3>
                 <input
                     type="hidden"
                     name="csrf_token"
@@ -184,13 +184,28 @@
                                     <strong>Last Stage Update:</strong>
                                     <span t-field="ticket.last_stage_update" />
                                     <br />
+                                    <strong>Attachments:</strong>
+                                    <br />
+                                    <t t-foreach="files" t-as="f">
+                                        <t t-if="f.access_token">
+                                        <a
+                                                t-attf-href="/web/content/#{f.id}?download=true&amp;access_token=#{f.access_token}"
+                                                target="_blank"
+                                            >
+                                            <span class="fa fa-download" />
+                                            <span t-esc="f.name" />
+                                        </a>
+                                        <br />
+                                    </t>
+                                    </t>
                                 </div>
                             </div>
-                            <br />
-                            <br />
-                            <h4 class="page-header">Description</h4>
-                            <t t-raw="ticket.description" />
-                            <br />
+                            <div class="row mt8">
+                                <div class="col-md-12">
+                                    <h4 class="page-header">Description</h4>
+                                    <t t-raw="ticket.description" /><br />
+                                </div>
+                            </div>
                         </div>
                         <h4 class="page-header">History</h4>
                         <!-- Options:Ticket Chatter: user can reply -->


### PR DESCRIPTION
This PR has been split from #448

- Add a list of attachments in the ticket portal view.
- When a ticket is created by a customer with attachments, an access token is automatically generated.
