### PR TITLE
[14.0][FW-PORT] helpdesk_mgmt: Sequence field added to sort tickets

### DIFF
--- a/helpdesk_mgmt/models/helpdesk_ticket.py
+++ b/helpdesk_mgmt/models/helpdesk_ticket.py
@@ -6,7 +6,7 @@ class HelpdeskTicket(models.Model):
     _name = "helpdesk.ticket"
     _description = "Helpdesk Ticket"
     _rec_name = "number"
-    _order = "priority desc, number desc, id desc"
+    _order = "priority desc, sequence, number desc, id desc"
     _mail_post_access = "read"
     _inherit = ["mail.thread.cc", "mail.activity.mixin", "portal.mixin"]
 
@@ -102,6 +102,12 @@ class HelpdeskTicket(models.Model):
             ("blocked", "Blocked"),
         ],
         string="Kanban State",
+    )
+    sequence = fields.Integer(
+        string="Sequence",
+        index=True,
+        default=10,
+        help="Gives the sequence order when displaying a list of tickets.",
     )
     active = fields.Boolean(default=True)
 

--- a/helpdesk_mgmt/views/helpdesk_ticket_views.xml
+++ b/helpdesk_mgmt/views/helpdesk_ticket_views.xml
@@ -187,6 +187,7 @@
                                 widget="many2many_tags"
                                 options="{'no_create_edit': True}"
                             />
+                            <field name="sequence" groups="base.group_no_one" />
                         </group>
                     </group>
                     <group>
@@ -243,6 +244,7 @@
                 <field name="name" />
                 <field name="partner_name" />
                 <field name="user_id" />
+                <field name="sequence" />
                 <field name="color" />
                 <field name="stage_id" />
                 <field name="priority" widget="priority" />

--- a/helpdesk_mgmt/views/helpdesk_ticket_views.xml
+++ b/helpdesk_mgmt/views/helpdesk_ticket_views.xml
@@ -224,13 +224,32 @@
             <tree>
                 <field name="priority" widget="priority" />
                 <field name="sequence" widget="handle" />
-                <field name="number" />
+                <field name="number" decoration-bf="1" />
                 <field name="name" />
-                <field name="partner_name" />
-                <field name="user_id" />
-                <field name="stage_id" />
-                <field name="create_date" readonly="1" />
-                <field name="last_stage_update" />
+                <field name="partner_id" optional="hide" widget="many2one_avatar" />
+                <field name="partner_name" optional="show" />
+                <field name="user_id" optional="show" widget="many2one_avatar_user" />
+                <field name="unattended" invisible="1" />
+                <field name="closed" invisible="1" />
+                <field
+                    name="create_date"
+                    widget="remaining_days"
+                    readonly="1"
+                    optional="show"
+                />
+                <field
+                    name="last_stage_update"
+                    widget="remaining_days"
+                    optional="show"
+                />
+                <field name="activity_ids" widget="list_activity" optional="hide" />
+                <field
+                    name="stage_id"
+                    widget="badge"
+                    decoration-success="not unattended and not closed"
+                    decoration-info="unattended == True"
+                    decoration-muted="closed == True"
+                />
             </tree>
         </field>
     </record>

--- a/helpdesk_mgmt/views/helpdesk_ticket_views.xml
+++ b/helpdesk_mgmt/views/helpdesk_ticket_views.xml
@@ -222,12 +222,13 @@
         <field name="model">helpdesk.ticket</field>
         <field name="arch" type="xml">
             <tree>
+                <field name="priority" widget="priority" />
+                <field name="sequence" widget="handle" />
                 <field name="number" />
                 <field name="name" />
                 <field name="partner_name" />
                 <field name="user_id" />
                 <field name="stage_id" />
-                <field name="priority" widget="priority" />
                 <field name="create_date" readonly="1" />
                 <field name="last_stage_update" />
             </tree>


### PR DESCRIPTION
This PR has been split from #448

- Sequence field added to allow kanban reordering.