### PR TITLE
[14.0][FW-PORT] helpdesk_mgmt: Allow portal user to close its tickets

### DIFF
--- a/helpdesk_mgmt/controllers/main.py
+++ b/helpdesk_mgmt/controllers/main.py
@@ -20,14 +20,22 @@ class HelpdeskTicketController(http.Controller):
                 values[field_name] = int(field_value)
             else:
                 values[field_name] = field_value
-        ticket = (
-            http.request.env["helpdesk.ticket"]
-            .sudo()
-            .search([("id", "=", values["ticket_id"])])
-        )
-        ticket.stage_id = values.get("stage_id")
-
-        return werkzeug.utils.redirect("/my/ticket/" + str(ticket.id))
+        if "ticket_id" in values:
+            ticket = (
+                http.request.env["helpdesk.ticket"]
+                .sudo()
+                .search([("id", "=", values.get("ticket_id"))])
+            )
+            if ticket and "stage_id" in values:
+                stage = (
+                    http.request.env["helpdesk.ticket.stage"]
+                    .sudo()
+                    .search([("id", "=", values.get("stage_id"))])
+                )
+                if stage and stage.portal_user_can_close:
+                    ticket.stage_id = stage
+                return werkzeug.utils.redirect("/my/ticket/" + str(ticket.id))
+        return werkzeug.utils.redirect("/my/tickets")
 
     def _get_teams(self):
         return (

--- a/helpdesk_mgmt/controllers/main.py
+++ b/helpdesk_mgmt/controllers/main.py
@@ -11,7 +11,9 @@ _logger = logging.getLogger(__name__)
 
 
 class HelpdeskTicketController(http.Controller):
-    @http.route("/ticket/close", type="http", auth="user")
+    """ """
+
+    @http.route("/close/ticket", type="http", auth="user")
     def support_ticket_close(self, **kw):
         """Close the support ticket"""
         values = {}

--- a/helpdesk_mgmt/data/helpdesk_data.xml
+++ b/helpdesk_mgmt/data/helpdesk_data.xml
@@ -180,6 +180,7 @@
             <field name="unattended">False</field>
             <field name="closed">True</field>
             <field name="fold">True</field>
+            <field name="portal_user_can_close">True</field>
             <field name="mail_template_id" ref="helpdesk_mgmt.closed_ticket_template" />
             <field name="company_id" />
         </record>
@@ -189,6 +190,7 @@
             <field name="unattended">False</field>
             <field name="closed">True</field>
             <field name="fold">True</field>
+            <field name="portal_user_can_close">True</field>
             <field name="mail_template_id" ref="helpdesk_mgmt.closed_ticket_template" />
             <field name="company_id" />
         </record>

--- a/helpdesk_mgmt/models/helpdesk_ticket_stage.py
+++ b/helpdesk_mgmt/models/helpdesk_ticket_stage.py
@@ -12,6 +12,10 @@ class HelpdeskTicketStage(models.Model):
     active = fields.Boolean(default=True)
     unattended = fields.Boolean(string="Unattended")
     closed = fields.Boolean(string="Closed")
+    portal_user_can_close = fields.Boolean(
+        help="If checked, a portal user will be able to close a ticket "
+        "in this stage from the portal"
+    )
     mail_template_id = fields.Many2one(
         comodel_name="mail.template",
         string="Email Template",

--- a/helpdesk_mgmt/tests/test_helpdesk_portal.py
+++ b/helpdesk_mgmt/tests/test_helpdesk_portal.py
@@ -43,6 +43,11 @@ class TestHelpdeskPortal(odoo.tests.HttpCase):
         self.portal_ticket = self._create_ticket(
             self.partner_portal, "portal-ticket-title"
         )
+        # Tickets stages
+        self.stage_cancelled = self.env.ref(
+            "helpdesk_mgmt.helpdesk_ticket_stage_cancelled"
+        )
+        self.stage_done = self.env.ref("helpdesk_mgmt.helpdesk_ticket_stage_done")
 
     def get_new_tickets(self, user):
         return self.env["helpdesk.ticket"].with_user(user).search([])
@@ -71,6 +76,21 @@ class TestHelpdeskPortal(odoo.tests.HttpCase):
         )
         self.assertEqual(resp.status_code, 200)
 
+    def _close_ticket(self, ticket_id, cancel):
+        if cancel:
+            stage_id = self.stage_cancelled
+        else:
+            stage_id = self.stage_done
+        resp = self.url_open(
+            "/close/ticket",
+            data={
+                "ticket_id": ticket_id.id,
+                "stage_id": stage_id.id,
+                "csrf_token": http.WebRequest.csrf_token(self),
+            },
+        )
+        self.assertEqual(resp.status_code, 200)
+
     def test_submit_ticket_01(self):
         self.authenticate("test-user", "test-user")
         self._submit_ticket()
@@ -92,3 +112,15 @@ class TestHelpdeskPortal(odoo.tests.HttpCase):
             "<p>" + "<br>".join(self.new_ticket_desc_lines) + "</p>",
             tickets.mapped("description"),
         )
+
+    def test_portal_user_close_ticket_01(self):
+        self.authenticate("test-portal", "test-portal")
+        self.assertTrue(self.stage_done.portal_user_can_close)
+        self._close_ticket(self.portal_ticket, cancel=False)
+        self.assertEqual(self.portal_ticket.stage_id, self.stage_done)
+
+    def test_portal_user_close_ticket_02(self):
+        self.authenticate("test-portal", "test-portal")
+        self.assertTrue(self.stage_cancelled.portal_user_can_close)
+        self._close_ticket(self.portal_ticket, cancel=True)
+        self.assertEqual(self.portal_ticket.stage_id, self.stage_cancelled)

--- a/helpdesk_mgmt/views/helpdesk_ticket_stage_views.xml
+++ b/helpdesk_mgmt/views/helpdesk_ticket_stage_views.xml
@@ -55,6 +55,10 @@
                         <group name="main_right">
                             <field name="fold" />
                             <field name="closed" />
+                            <field
+                                name="portal_user_can_close"
+                                attrs="{'invisible': [('closed', '=', False)]}"
+                            />
                             <field name="unattended" />
                         </group>
                     </group>

--- a/helpdesk_mgmt/views/helpdesk_ticket_templates.xml
+++ b/helpdesk_mgmt/views/helpdesk_ticket_templates.xml
@@ -136,31 +136,33 @@
                                     <span t-field="ticket.name" />
                                 </h4>
                             </div>
+                            <div class="col-md-6">
                             <t t-foreach="closed_stages" t-as="stage">
                                 <form
-                                    method="GET"
-                                    t-if="not ticket.closed_date"
-                                    t-attf-action="/ticket/close"
-                                    style="display:inline;"
-                                >
-                                    <input
-                                        type="hidden"
-                                        name="ticket_id"
-                                        t-attf-value="#{ticket.id}"
-                                    />
-                                    <input
-                                        type="hidden"
-                                        name="stage_id"
-                                        t-attf-value="#{stage.id}"
-                                    />
-                                    <button
-                                        class="btn btn-success pull-right"
-                                        style="margin-right:15px;margin-top:3px;"
+                                        method="GET"
+                                        t-if="not ticket.closed_date and stage.portal_user_can_close"
+                                        t-attf-action="/ticket/close"
+                                        style="display:inline;"
                                     >
-                                        <span t-field="stage.name" />
+                                    <input
+                                            type="hidden"
+                                            name="ticket_id"
+                                            t-attf-value="#{ticket.id}"
+                                        />
+                                    <input
+                                            type="hidden"
+                                            name="stage_id"
+                                            t-attf-value="#{stage.id}"
+                                        />
+                                    <button
+                                            class="btn btn-outline-success btn-sm pull-right"
+                                            style="margin-left:5px;margin-top:3px;"
+                                        >
+                                        Mark as "<span t-field="stage.name" />"
                                     </button>
                                 </form>
                             </t>
+                        </div>
                         </div>
                     </div>
                     <div class="panel-body">


### PR DESCRIPTION
This PR has been split from #448

- Allow a portal user to close its ticket if the final stage is set with `portal_user_can_close`.
