### PR TITLE
[16.0][IMP] helpdesk_mgmt: ticket - added search by title

### DIFF
--- a/helpdesk_mgmt/models/helpdesk_ticket.py
+++ b/helpdesk_mgmt/models/helpdesk_ticket.py
@@ -6,6 +6,7 @@ class HelpdeskTicket(models.Model):
     _name = "helpdesk.ticket"
     _description = "Helpdesk Ticket"
     _rec_name = "number"
+    _rec_names_search = ["number", "name"]
     _order = "priority desc, sequence, number desc, id desc"
     _mail_post_access = "read"
     _inherit = ["mail.thread.cc", "mail.activity.mixin", "portal.mixin"]


### PR DESCRIPTION
This improvement simply uses new `_rec_names_search` model attribute for helpdesk tickets, so in `Many2one` fields now it's possible to search across ticket title.