### PR TITLE
[14.0][FIX] Email formating when receive it by mail gateway, create new ticket with wrong label

### DIFF
--- a/helpdesk_mgmt/models/helpdesk_ticket.py
+++ b/helpdesk_mgmt/models/helpdesk_ticket.py
@@ -213,12 +213,17 @@ class HelpdeskTicket(models.Model):
         """
         if custom_values is None:
             custom_values = {}
+        partner_name, partner_email = next(
+            iter(tools.email_split_tuples(msg.get("from"))), ("", "")
+        )
         defaults = {
             "name": msg.get("subject") or _("No Subject"),
             "description": msg.get("body"),
-            "partner_email": msg.get("from"),
+            "partner_email": partner_email,
             "partner_id": msg.get("author_id"),
         }
+        if not msg.get("author_id"):
+            defaults["partner_name"] = partner_name
         defaults.update(custom_values)
 
         # Write default values coming from msg

--- a/helpdesk_mgmt/tests/test_helpdesk_ticket.py
+++ b/helpdesk_mgmt/tests/test_helpdesk_ticket.py
@@ -75,6 +75,7 @@ class TestHelpdeskTicket(TestHelpdeskTicketBase):
             "message_id": msg_id,
             "subject": title,
             "email_from": "Bob <bob@example.com>",
+            "from": "Bob <bob@example.com>",
             "to": "jill@example.com",
             "cc": "sally@example.com",
             "recipients": "jill@example.com+sally@example.com",


### PR DESCRIPTION
[FIX] helpdesk_mgmt: format email when receive it from new message mail gateway

Before, email was like '"Name" <name@company.com>'
Now, email is like 'name@company.com'
To field partner_email into model helpdesk.ticket