### PR TITLE
[16.0][FIX] helpdesk_mgmt: Reintroduce `create_date` in list view

### DIFF
--- a/helpdesk_mgmt/views/helpdesk_ticket_views.xml
+++ b/helpdesk_mgmt/views/helpdesk_ticket_views.xml
@@ -227,6 +227,12 @@
                     optional="show"
                 />
                 <field
+                    name="create_date"
+                    widget="remaining_days"
+                    readonly="1"
+                    optional="show"
+                />
+                <field
                     name="last_stage_update"
                     widget="remaining_days"
                     optional="show"


### PR DESCRIPTION
The field was accidentally removed in commit 7f0a9f5a

cc @pedrobaeza 