### PR TITLE
[16.0][FIX] helpdesk_mgmt_timesheet: wrong variable on report

### DIFF
--- a/helpdesk_mgmt_timesheet/report/report_timesheet_templates.xml
+++ b/helpdesk_mgmt_timesheet/report/report_timesheet_templates.xml
@@ -18,8 +18,8 @@
         </xpath>
         <xpath expr="//table[hasclass('table-sm')]/tbody/tr[1]/td[3]" position="after">
             <td t-if="show_ticket" groups="helpdesk_mgmt.group_helpdesk_user">
-                <span t-field="l.ticket_id.number" /> - <span
-                    t-field="l.ticket_id.name"
+                <span t-field="line.ticket_id.number" /> - <span
+                    t-field="line.ticket_id.name"
                 />
             </td>
         </xpath>


### PR DESCRIPTION
If you try to print timesheets report from tickets:
```
Traceback (most recent call last):
  File "<707>", line 608, in template_707
  File "<707>", line 286, in template_707_content
KeyError: 'l'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/opt/odoo/addons/web/controllers/report.py", line 113, in report_download
    response = self.report_routes(reportname, docids=docids, converter=converter, context=context)
  File "/opt/odoo/odoo/http.py", line 697, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "/opt/odoo/addons/web/controllers/report.py", line 42, in report_routes
    pdf = report.with_context(context)._render_qweb_pdf(reportname, docids, data=data)[0]
  File "/opt/odoo/odoo/addons/base/models/ir_actions_report.py", line 807, in _render_qweb_pdf
    collected_streams = self._render_qweb_pdf_prepare_streams(report_ref, data, res_ids=res_ids)
  File "/opt/odoo/odoo/addons/base/models/ir_actions_report.py", line 708, in _render_qweb_pdf_prepare_streams
    html = self.with_context(**additional_context)._render_qweb_html(report_ref, res_ids_wo_stream, data=data)[0]
  File "/opt/odoo/odoo/addons/base/models/ir_actions_report.py", line 884, in _render_qweb_html
    return self._render_template(report.report_name, data), 'html'
  File "/opt/odoo/odoo/addons/base/models/ir_actions_report.py", line 623, in _render_template
    return view_obj._render_template(template, values).encode()
  File "/opt/odoo/odoo/addons/base/models/ir_ui_view.py", line 2128, in _render_template
    return self.env['ir.qweb']._render(template, values)
  File "/opt/odoo/odoo/tools/profiler.py", line 292, in _tracked_method_render
    return method_render(self, template, values, **options)
  File "/opt/odoo/odoo/addons/base/models/ir_qweb.py", line 580, in _render
    result = ''.join(rendering)
  File "<709>", line 96, in template_709
  File "<709>", line 78, in template_709_content
  File "<709>", line 61, in template_709_t_call_0
  File "<709>", line 53, in template_709_t_call_1
  File "<707>", line 614, in template_707
odoo.addons.base.models.ir_qweb.QWebException: Error while render the template
KeyError: 'l'
Template: hr_timesheet.timesheet_table
Path: /t/div/div/table/tbody/tr[1]/td[4]/span[1]
Node: <span t-field="l.ticket_id.number"/>

The above server error caused the following client error:
RPC_ERROR: Odoo Server Error
    at makeErrorFromResponse (http://oca-helpdesk-16-0-2c86cf79f12d.runboat.odoo-community.org/web/assets/403-fc4ce55/web.assets_backend.min.js:985:163)
    at decoder.onload (http://oca-helpdesk-16-0-2c86cf79f12d.runboat.odoo-community.org/web/assets/403-fc4ce55/web.assets_backend.min.js:973:7)
```