### PR TITLE
[13.0][FIX]Display "Ticket number & Title" Labels for fields "number & name" - Update helpdesk_ticket_views.xml for ODOO v13.0

### DIFF
--- a/helpdesk_mgmt/views/helpdesk_ticket_views.xml
+++ b/helpdesk_mgmt/views/helpdesk_ticket_views.xml
@@ -141,9 +141,11 @@
                     </div>
                     <div class="oe_title">
                         <h1 class="oe_title">
+                            <label for="number"/>
                             <field name="number" />
                         </h1>
                         <h2 class="o_row">
+                            <label for="name"/>
                             <field name="name" />
                         </h2>
                     </div>


### PR DESCRIPTION
To make labels for fields number and name visible. Respectively Ticket number and Title (Labels).
![HelpdeskTicket-Before](https://github.com/OCA/helpdesk/assets/3822648/bd9c521d-fefb-4607-bcd0-ca9a4ea1f758)
![HelpdeskTicket-After](https://github.com/OCA/helpdesk/assets/3822648/a5448cce-ddd7-416d-bbbe-3efb3552c3a8)
