### PR TITLE
[15.0][FIX] helpdesk_mgmt: Fixes to automatic email sending according to stage

### DIFF
--- a/helpdesk_mgmt/controllers/main.py
+++ b/helpdesk_mgmt/controllers/main.py
@@ -75,6 +75,11 @@ class HelpdeskTicketController(http.Controller):
             "partner_id": request.env.user.partner_id.id,
             "partner_name": request.env.user.partner_id.name,
             "partner_email": request.env.user.partner_id.email,
+            # Need to set stage_id so that the _track_template() method is called
+            # and the mail is sent automatically if applicable
+            "stage_id": request.env["helpdesk.ticket"].default_get(["stage_id"])[
+                "stage_id"
+            ],
         }
         if company.helpdesk_mgmt_portal_select_team:
             team = (

--- a/helpdesk_mgmt/models/helpdesk_ticket.py
+++ b/helpdesk_mgmt/models/helpdesk_ticket.py
@@ -180,6 +180,8 @@ class HelpdeskTicket(models.Model):
             res["stage_id"] = (
                 ticket.stage_id.mail_template_id,
                 {
+                    # Need to set mass_mail so that the email will always be sent
+                    "composition_mode": "mass_mail",
                     "auto_delete_message": True,
                     "subtype_id": self.env["ir.model.data"]._xmlid_to_res_id(
                         "mail.mt_note"


### PR DESCRIPTION
Fixes to automatic email sending according to stage:

- [x] Set `stage_id` in the ticket creation from portal so that `_track_template()` method has the correct behavior.
- [x] Set composition_mode=mass_mail so that the email is always sent (for example if the ticket is created from portal).

Please @pedrobaeza and @chienandalu can you review it?

@Tecnativa TT45288