### PR TITLE
[15.0][FIX+IMP] helpdesk_type: some views adjustments

### DIFF
--- a/helpdesk_type/views/helpdesk_ticket.xml
+++ b/helpdesk_type/views/helpdesk_ticket.xml
@@ -34,4 +34,26 @@
             </xpath>
         </field>
     </record>
+    <record id="ticket_view_tree" model="ir.ui.view">
+        <field name="name">helpdesk.ticket.view.tree (in helpdesk_type)</field>
+        <field name="model">helpdesk.ticket</field>
+        <field name="inherit_id" ref="helpdesk_mgmt.ticket_view_tree" />
+        <field name="arch" type="xml">
+            <field name="tag_ids" position="before">
+                <field name="type_id" optional="show" />
+            </field>
+        </field>
+    </record>
+    <record id="view_helpdesk_ticket_kanban" model="ir.ui.view">
+        <field name="name">helpdesk.ticket.kanban (in helpdesk_type)</field>
+        <field name="model">helpdesk.ticket</field>
+        <field name="inherit_id" ref="helpdesk_mgmt.view_helpdesk_ticket_kanban" />
+        <field name="arch" type="xml">
+            <xpath expr="//templates//field[@name='number']" position="after">
+                <small class="o_kanban_record_subtitle">
+                    <i><field name="type_id" /></i>
+                </small>
+            </xpath>
+        </field>
+    </record>
 </odoo>

--- a/helpdesk_type/views/helpdesk_ticket_team.xml
+++ b/helpdesk_type/views/helpdesk_ticket_team.xml
@@ -6,7 +6,7 @@
         <field name="model">helpdesk.ticket.team</field>
         <field name="inherit_id" ref="helpdesk_mgmt.view_helpdesk_team_form" />
         <field name="arch" type="xml">
-            <field name="user_ids" position="after">
+            <field name="show_in_portal" position="after">
                 <field name="type_ids" widget="many2many_tags" />
             </field>
         </field>


### PR DESCRIPTION
Some minor adjustments for `type_id` views.

* _Location in teams `form`_. Before:
  ![imagen](https://github.com/OCA/helpdesk/assets/12749832/7f252b76-cbba-401f-bfa2-e53ee45a2e41)
  
  After:
  ![imagen](https://github.com/OCA/helpdesk/assets/12749832/1a341f2c-598b-4e6b-92b4-0e5f87b62c50)
 
* _Added to `tree` (optional) and `kanban` views_. In this one:  
  ![imagen](https://github.com/OCA/helpdesk/assets/12749832/1b45f843-71ae-4892-98fa-e3f81d067578)

