### PR TITLE
[15.0][FIX] helpdesk_mgmt: Avoid malformed domain error + Change to read_group() method

### DIFF
--- a/helpdesk_mgmt/tests/test_res_partner.py
+++ b/helpdesk_mgmt/tests/test_res_partner.py
@@ -1,7 +1,7 @@
-from odoo.tests.common import TransactionCase
+from odoo.tests import Form, common
 
 
-class TestPartner(TransactionCase):
+class TestPartner(common.TransactionCase):
     def setUp(self):
         super().setUp()
         self.partner_obj = self.env["res.partner"]
@@ -40,3 +40,7 @@ class TestPartner(TransactionCase):
 
     def test_ticket_string(self):
         self.assertEqual(self.parent_id.helpdesk_ticket_count_string, "3 / 4")
+
+    def test_partner_form_helpdesk_ticket_count(self):
+        partner_form = Form(self.env["res.partner"])
+        self.assertEqual(partner_form.helpdesk_ticket_count, 0)


### PR DESCRIPTION
Avoid malformed domain error + Change to `read_group()` method

`TypeError: 'NewId' object is not iterable` (since https://github.com/odoo/odoo/commit/7fc3ebf0fabe3d87f98d31fccd1a7eb2618f8f5f)

Please @pedrobaeza and @chienandalu can you review it?

@Tecnativa TT45844