### PR TITLE
[16.0][FIX] helpdesk_mgmt:  Remove relation m2m on helpdesk.ticket.team

### DIFF
--- a/helpdesk_mgmt/models/helpdesk_ticket_stage.py
+++ b/helpdesk_mgmt/models/helpdesk_ticket_stage.py
@@ -37,7 +37,6 @@ class HelpdeskTicketStage(models.Model):
     )
     team_ids = fields.Many2many(
         comodel_name="helpdesk.ticket.team",
-        relation="team_stage_rel",
         string="Helpdesk Teams",
         help="Specific team that uses this stage. If it is empty all teams could uses",
         domain="['|', ('company_id', '=', False), ('company_id', '=', company_id)]",


### PR DESCRIPTION
Remove relation m2m on field team_ids in order to avoid this error message:
odoo.sql_db: bad query: ALTER TABLE "team_stage_rel" ADD FOREIGN KEY ("helpdesk_ticket_stage_id") REFERENCES "helpdesk_ticket_stage"("id") ON DELETE cascade

@Tecnativa
TT47414

@pedrobaeza