### PR TITLE
Make channel name translatable

### DIFF
--- a/helpdesk_mgmt/models/helpdesk_ticket_channel.py
+++ b/helpdesk_mgmt/models/helpdesk_ticket_channel.py
@@ -8,7 +8,10 @@ class HelpdeskTicketChannel(models.Model):
     _order = "sequence, id"
 
     sequence = fields.Integer(default=10)
-    name = fields.Char(required=True)
+    name = fields.Char(
+        required=True,
+        translate=True,
+    )
     active = fields.Boolean(default=True)
     company_id = fields.Many2one(
         comodel_name="res.company",


### PR DESCRIPTION
[IMP] helpdesk_mgmt: Make channel name translatable

The channel name in multilanguage environments should be translatable to the system's active language. In case the channel name is not translatable, when the user is configuring the helpdesk for a multilanguage audience he is forced to choose one language only and that may become non understandable for all other languages.

