### PR TITLE
[16.0][FIX] helpdesk_mgmt_timesheet: add group on show_time_control

### DIFF
--- a/helpdesk_mgmt_timesheet/views/helpdesk_ticket_view.xml
+++ b/helpdesk_mgmt_timesheet/views/helpdesk_ticket_view.xml
@@ -54,7 +54,11 @@
                 />
             </field>
             <tree position="inside">
-                <field name="show_time_control" invisible="1" />
+                <field
+                    name="show_time_control"
+                    invisible="1"
+                    groups="hr_timesheet.group_hr_timesheet_user"
+                />
                 <button
                     name="button_start_work"
                     title="Start work"
@@ -87,7 +91,11 @@
         <field name="priority" eval="20" />
         <field name="arch" type="xml">
             <div name="button_box" position="inside">
-                <field name="show_time_control" invisible="1" />
+                <field
+                    name="show_time_control"
+                    invisible="1"
+                    groups="hr_timesheet.group_hr_timesheet_user"
+                />
                 <button
                     name="button_start_work"
                     title="Start work"
@@ -217,7 +225,11 @@
         <field name="inherit_id" ref="helpdesk_mgmt.view_helpdesk_ticket_kanban" />
         <field name="arch" type="xml">
             <xpath expr="//*[hasclass('oe_kanban_bottom_left')]" position="inside">
-                <field name="show_time_control" invisible="1" />
+                <field
+                    name="show_time_control"
+                    invisible="1"
+                    groups="hr_timesheet.group_hr_timesheet_user"
+                />
                 <a
                     name="button_start_work"
                     title="Start work"


### PR DESCRIPTION
This field is computed by accessing "account.analytic.line", which default helpdesk users have no access to. The field is only used in domains for displayed to group hr_timesheet.group_hr_timesheet_user, so limit the field to that group too.
The group hr_timesheet.group_hr_timesheet_user has already access to "account.analytic.line".