### PR TITLE
[FIX[[16] helpdesk_mgmt_project: Fix id instead of active_id used in smartbuttons

### DIFF
--- a/helpdesk_mgmt_project/views/project_view.xml
+++ b/helpdesk_mgmt_project/views/project_view.xml
@@ -10,7 +10,7 @@
                     type="action"
                     icon="fa-file"
                     name="%(ticket_action_from_project)d"
-                    context="{'search_default_project_id': active_id, 'default_project_id': active_id}"
+                    context="{'search_default_project_id': id, 'default_project_id': id}"
                     groups="helpdesk_mgmt.group_helpdesk_user_own"
                 >
                     <field string="Tickets" name="ticket_count" widget="statinfo" />
@@ -37,7 +37,7 @@
                     class="o_project_kanban_box"
                     name="%(ticket_action_from_project)d"
                     type="action"
-                    context="{'search_default_project_id': active_id, 'default_project_id': active_id}"
+                    context="{'search_default_project_id': id, 'default_project_id': id}"
                     groups="helpdesk_mgmt.group_helpdesk_user_own"
                 >
                     <div>


### PR DESCRIPTION
Using active_id in the context is wrong because if landing in the project starting from  another model, the active_id is the one of the previous model in the breadcrumb. ID should be used instead of active_id