### PR TITLE
[16.0][FIX] helpdesk_mgmt_timesheet: remove duplicate field 'default_project_id'

### DIFF
--- a/helpdesk_mgmt_timesheet/i18n/es.po
+++ b/helpdesk_mgmt_timesheet/i18n/es.po
@@ -39,11 +39,6 @@ msgid "Date"
 msgstr "Fecha"
 
 #. module: helpdesk_mgmt_timesheet
-#: model:ir.model.fields,field_description:helpdesk_mgmt_timesheet.field_helpdesk_ticket_team__default_project_id
-msgid "Default Project"
-msgstr "Proyecto por defecto"
-
-#. module: helpdesk_mgmt_timesheet
 #: model_terms:ir.ui.view,arch_db:helpdesk_mgmt_timesheet.timesheet_helpdesk_ticket_view_form
 msgid "Duration (Hour(s))"
 msgstr "Duración (Hora(s))"

--- a/helpdesk_mgmt_timesheet/i18n/es_AR.po
+++ b/helpdesk_mgmt_timesheet/i18n/es_AR.po
@@ -38,11 +38,6 @@ msgid "Date"
 msgstr "Fecha"
 
 #. module: helpdesk_mgmt_timesheet
-#: model:ir.model.fields,field_description:helpdesk_mgmt_timesheet.field_helpdesk_ticket_team__default_project_id
-msgid "Default Project"
-msgstr "Proyecto Predeterminado"
-
-#. module: helpdesk_mgmt_timesheet
 #: model_terms:ir.ui.view,arch_db:helpdesk_mgmt_timesheet.timesheet_helpdesk_ticket_view_form
 msgid "Duration (Hour(s))"
 msgstr "Duración (Hora(s))"

--- a/helpdesk_mgmt_timesheet/i18n/fr.po
+++ b/helpdesk_mgmt_timesheet/i18n/fr.po
@@ -38,11 +38,6 @@ msgid "Date"
 msgstr "Date"
 
 #. module: helpdesk_mgmt_timesheet
-#: model:ir.model.fields,field_description:helpdesk_mgmt_timesheet.field_helpdesk_ticket_team__default_project_id
-msgid "Default Project"
-msgstr "Projet par Défaut"
-
-#. module: helpdesk_mgmt_timesheet
 #: model_terms:ir.ui.view,arch_db:helpdesk_mgmt_timesheet.timesheet_helpdesk_ticket_view_form
 msgid "Duration (Hour(s))"
 msgstr "Durée (Heure(s))"

--- a/helpdesk_mgmt_timesheet/i18n/helpdesk_mgmt_timesheet.pot
+++ b/helpdesk_mgmt_timesheet/i18n/helpdesk_mgmt_timesheet.pot
@@ -35,11 +35,6 @@ msgid "Date"
 msgstr ""
 
 #. module: helpdesk_mgmt_timesheet
-#: model:ir.model.fields,field_description:helpdesk_mgmt_timesheet.field_helpdesk_ticket_team__default_project_id
-msgid "Default Project"
-msgstr ""
-
-#. module: helpdesk_mgmt_timesheet
 #: model_terms:ir.ui.view,arch_db:helpdesk_mgmt_timesheet.timesheet_helpdesk_ticket_view_form
 msgid "Duration (Hour(s))"
 msgstr ""

--- a/helpdesk_mgmt_timesheet/i18n/hu.po
+++ b/helpdesk_mgmt_timesheet/i18n/hu.po
@@ -40,11 +40,6 @@ msgid "Date"
 msgstr ""
 
 #. module: helpdesk_mgmt_timesheet
-#: model:ir.model.fields,field_description:helpdesk_mgmt_timesheet.field_helpdesk_ticket_team__default_project_id
-msgid "Default Project"
-msgstr "Alapértelmezett projekt"
-
-#. module: helpdesk_mgmt_timesheet
 #: model_terms:ir.ui.view,arch_db:helpdesk_mgmt_timesheet.timesheet_helpdesk_ticket_view_form
 msgid "Duration (Hour(s))"
 msgstr "Hossz (óra)"

--- a/helpdesk_mgmt_timesheet/i18n/it.po
+++ b/helpdesk_mgmt_timesheet/i18n/it.po
@@ -38,11 +38,6 @@ msgid "Date"
 msgstr "Data"
 
 #. module: helpdesk_mgmt_timesheet
-#: model:ir.model.fields,field_description:helpdesk_mgmt_timesheet.field_helpdesk_ticket_team__default_project_id
-msgid "Default Project"
-msgstr "Progetto predefinito"
-
-#. module: helpdesk_mgmt_timesheet
 #: model_terms:ir.ui.view,arch_db:helpdesk_mgmt_timesheet.timesheet_helpdesk_ticket_view_form
 msgid "Duration (Hour(s))"
 msgstr "Durata (ore)"

--- a/helpdesk_mgmt_timesheet/i18n/pt.po
+++ b/helpdesk_mgmt_timesheet/i18n/pt.po
@@ -38,11 +38,6 @@ msgid "Date"
 msgstr "Data"
 
 #. module: helpdesk_mgmt_timesheet
-#: model:ir.model.fields,field_description:helpdesk_mgmt_timesheet.field_helpdesk_ticket_team__default_project_id
-msgid "Default Project"
-msgstr "Projeto Predefinido"
-
-#. module: helpdesk_mgmt_timesheet
 #: model_terms:ir.ui.view,arch_db:helpdesk_mgmt_timesheet.timesheet_helpdesk_ticket_view_form
 msgid "Duration (Hour(s))"
 msgstr "Duração (Hora(s))"

--- a/helpdesk_mgmt_timesheet/i18n/pt_BR.po
+++ b/helpdesk_mgmt_timesheet/i18n/pt_BR.po
@@ -38,11 +38,6 @@ msgid "Date"
 msgstr "Data"
 
 #. module: helpdesk_mgmt_timesheet
-#: model:ir.model.fields,field_description:helpdesk_mgmt_timesheet.field_helpdesk_ticket_team__default_project_id
-msgid "Default Project"
-msgstr "Projeto Padrão"
-
-#. module: helpdesk_mgmt_timesheet
 #: model_terms:ir.ui.view,arch_db:helpdesk_mgmt_timesheet.timesheet_helpdesk_ticket_view_form
 msgid "Duration (Hour(s))"
 msgstr "Duração (Hora(s))"

--- a/helpdesk_mgmt_timesheet/models/helpdesk_ticket_team.py
+++ b/helpdesk_mgmt_timesheet/models/helpdesk_ticket_team.py
@@ -8,10 +8,6 @@ class HelpdeskTicketTeam(models.Model):
     _inherit = "helpdesk.ticket.team"
 
     allow_timesheet = fields.Boolean()
-    default_project_id = fields.Many2one(
-        comodel_name="project.project",
-        string="Default Project",
-    )
 
     @api.constrains("allow_timesheet")
     def _constrains_allow_timesheet(self):

--- a/helpdesk_mgmt_timesheet/views/helpdesk_team_view.xml
+++ b/helpdesk_mgmt_timesheet/views/helpdesk_team_view.xml
@@ -8,11 +8,6 @@
         <field name="arch" type="xml">
             <xpath expr="//field[@name='alias_user_id']" position="after">
                 <field name="allow_timesheet" type="checkbox" />
-                <field
-                    name="default_project_id"
-                    attrs="{'invisible':[('allow_timesheet', '=', False)]}"
-                    help=" Change the Default Project will not have retroactive effects."
-                />
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
I have detected in the "helpdesk.ticket.team" model the "default_project_id" field appears duplicate. This field already appears in the "helpdesk_mgmt_project" module from which it inherits.
Also, in the view "helpdesk_team_view.xml" it duplicates this same field. This field appears by default for the module it inherits from, but when you check the "allow_timesheet" checkbox it appears again. 

I have removed this field from the model, from the views and translations, since it is in the module from which it inherits.





































































































