### PR TITLE
[16.0][IMP] helpdesk_mgmt: Update priority of portal_my_home template

### DIFF
--- a/helpdesk_mgmt/views/helpdesk_ticket_templates.xml
+++ b/helpdesk_mgmt/views/helpdesk_ticket_templates.xml
@@ -26,7 +26,7 @@
         id="portal_my_home"
         name="Portal My Home : ticket entries"
         inherit_id="portal.portal_my_home"
-        priority="40"
+        priority="99"
         customize_show="True"
     >
         <xpath expr="//div[hasclass('o_portal_docs')]" position="inside">


### PR DESCRIPTION
We can consider another strategy in the future, but for now, I believe that changing the priority of the portal's ticket menu to the "last position" will significantly improve its visual arrangement.

Priority 40
![image](https://github.com/OCA/helpdesk/assets/3595132/fec7df91-5e98-40ee-aa9e-c1e041d3475d)

Priority 99
![image](https://github.com/OCA/helpdesk/assets/3595132/8d9de980-d015-4fd6-8308-70821b30dba5)
