### PR TITLE
[16.0][FIX] helpdesk_mgmt: Tag tests as per recommendations for HttpCase type tests.

### DIFF
--- a/helpdesk_mgmt/__manifest__.py
+++ b/helpdesk_mgmt/__manifest__.py
@@ -4,7 +4,7 @@
     "name": "Helpdesk Management",
     "summary": """
         Helpdesk""",
-    "version": "16.0.2.4.0",
+    "version": "16.0.2.4.1",
     "license": "AGPL-3",
     "category": "After-Sales",
     "author": "AdaptiveCity, "

--- a/helpdesk_mgmt/tests/test_helpdesk_portal.py
+++ b/helpdesk_mgmt/tests/test_helpdesk_portal.py
@@ -2,11 +2,12 @@
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 # import odoo.tests
 from odoo import http
-from odoo.tests.common import new_test_user
+from odoo.tests.common import new_test_user, tagged
 
 from odoo.addons.base.tests.common import HttpCaseWithUserPortal
 
 
+@tagged("post_install", "-at_install")
 class TestHelpdeskPortalBase(HttpCaseWithUserPortal):
     """Test controllers defined for portal mode.
     This is mostly for basic coverage; we don't go as far as fully validating


### PR DESCRIPTION
The tests of helpdesk_mgmt derived from HttpCase fail when we run them together with some personal addons. Tagging the tests as `@tagged("post_install", "-at_install")` as recommended [1] by Odoo fixes the issue without any downside.

[1] https://www.odoo.com/documentation/16.0/developer/reference/backend/testing.html#special-tags