### PR TITLE
[FIX][16.0]helpdesk_mgmt_timesheet: add proper import to trigger the proper closest suggestion

### DIFF
--- a/helpdesk_mgmt_timesheet/__init__.py
+++ b/helpdesk_mgmt_timesheet/__init__.py
@@ -3,3 +3,4 @@
 ###############################################################################
 from . import models
 from . import controllers
+from . import wizards

--- a/helpdesk_mgmt_timesheet/wizards/hr_timesheet_switch.py
+++ b/helpdesk_mgmt_timesheet/wizards/hr_timesheet_switch.py
@@ -16,7 +16,7 @@ class HrTimesheetSwitch(models.TransientModel):
             and self.env.context["active_model"] == "helpdesk.ticket"
             and self.env.user
         ):
-            return self.env["account.analytic.line"].search(
+            result = self.env["account.analytic.line"].search(
                 [
                     ("user_id", "=", self.env.user.id),
                     ("ticket_id", "=", self.env.context["active_id"]),


### PR DESCRIPTION
Don't really know why but wizards weren't imported in the init file.

Additionnaly make the inherits method to have a single return instead of multiple ones