### PR TITLE
[16.0][FIX] helpdesk_mgmt_timesheet: Remove field access restriction

### DIFF
--- a/helpdesk_mgmt_timesheet/models/hr_timesheet.py
+++ b/helpdesk_mgmt_timesheet/models/hr_timesheet.py
@@ -11,7 +11,6 @@ class AccountAnalyticLine(models.Model):
         comodel_name="helpdesk.ticket",
         string="Ticket",
         domain=[("project_id", "!=", False)],
-        groups="helpdesk_mgmt.group_helpdesk_user",
     )
     ticket_partner_id = fields.Many2one(
         comodel_name="res.partner",
@@ -19,7 +18,6 @@ class AccountAnalyticLine(models.Model):
         string="Ticket partner",
         store=True,
         compute_sudo=True,
-        groups="helpdesk_mgmt.group_helpdesk_user",
     )
 
     @api.onchange("ticket_id")


### PR DESCRIPTION
- Prevents users from being able to browse the records without Helpdesk User group
- Groups already defined on views.

@Tecnativa
@pedrobaeza