### PR TITLE
[16.0][FIX] helpdesk_mgmt_timesheet: prevent selecting internal projects

### DIFF
--- a/helpdesk_mgmt_timesheet/models/helpdesk_ticket.py
+++ b/helpdesk_mgmt_timesheet/models/helpdesk_ticket.py
@@ -12,6 +12,7 @@ class HelpdeskTicket(models.Model):
     def _relation_with_timesheet_line(self):
         return "ticket_id"
 
+    project_id = fields.Many2one(domain=[("is_internal_project", "=", False)])
     allow_timesheet = fields.Boolean(
         string="Allow Timesheet",
         related="team_id.allow_timesheet",

--- a/helpdesk_mgmt_timesheet/models/helpdesk_ticket_team.py
+++ b/helpdesk_mgmt_timesheet/models/helpdesk_ticket_team.py
@@ -7,6 +7,7 @@ from odoo import api, fields, models
 class HelpdeskTicketTeam(models.Model):
     _inherit = "helpdesk.ticket.team"
 
+    default_project_id = fields.Many2one(domain=[("is_internal_project", "=", False)])
     allow_timesheet = fields.Boolean()
 
     @api.constrains("allow_timesheet")


### PR DESCRIPTION
Internal projects are not displayed in project default view as they are meant to store time off and similar timesheet lines.