### PR TITLE
[15.0] FIX helpdesk_mgmt when disabling "Required Category" in portal settings

### DIFF
--- a/helpdesk_mgmt/controllers/main.py
+++ b/helpdesk_mgmt/controllers/main.py
@@ -70,7 +70,7 @@ class HelpdeskTicketController(http.Controller):
 
     def _prepare_submit_ticket_vals(self, **kw):
         category = http.request.env["helpdesk.ticket.category"].browse(
-            int(kw.get("category"))
+            int(kw.get("category") or 0)
         )
         company = category.company_id or http.request.env.company
         vals = {


### PR DESCRIPTION
 - Disable "Required Category" in helpdesk settings 

![image](https://github.com/user-attachments/assets/e6bc7821-e307-4b1c-bb84-00801a89e581)

 - Create a ticket by /new/ticket with empty category 

![error](https://github.com/user-attachments/assets/a275ab6f-fb87-4483-8b0c-dbf282de911a)


Get

File "/mnt/data/odoo-addons-dir/helpdesk_mgmt/controllers/main.py", line 73, in _prepare_submit_ticket_vals
    int(kw.get("category"))
ValueError: invalid literal for int() with base 10: ''