### PR TITLE
[16.0][IMP] helpdesk_mgmt_project: Multi-company compatibility

### DIFF
--- a/helpdesk_mgmt_project/__manifest__.py
+++ b/helpdesk_mgmt_project/__manifest__.py
@@ -3,7 +3,7 @@
 {
     "name": "Helpdesk Project",
     "summary": "Add the option to select project in the tickets.",
-    "version": "16.0.2.1.0",
+    "version": "16.0.2.2.0",
     "license": "AGPL-3",
     "category": "After-Sales",
     "author": "PuntSistemes S.L.U., " "Odoo Community Association (OCA)",

--- a/helpdesk_mgmt_project/migrations/16.0.2.2.0/post-migration.py
+++ b/helpdesk_mgmt_project/migrations/16.0.2.2.0/post-migration.py
@@ -1,0 +1,20 @@
+# Copyright 2024 Tecnativa - Víctor Martínez
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    """Set the default_project_id value in the project company."""
+    env.cr.execute(
+        """
+        SELECT htt.id, htt.old_default_project_id, pp.company_id
+        FROM helpdesk_ticket_team htt
+        JOIN project_project pp ON htt.old_default_project_id = pp.id
+        WHERE htt.old_default_project_id IS NOT NULL
+        """
+    )
+    for team_id, old_default_project_id, company_id in env.cr.fetchall():
+        team = env["helpdesk.ticket.team"].with_company(company_id).browse(team_id)
+        team.write({"default_project_id": old_default_project_id})

--- a/helpdesk_mgmt_project/migrations/16.0.2.2.0/pre-migration.py
+++ b/helpdesk_mgmt_project/migrations/16.0.2.2.0/pre-migration.py
@@ -1,0 +1,14 @@
+# Copyright 2024 Tecnativa - Víctor Martínez
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from openupgradelib import openupgrade
+
+column_renames = {
+    "helpdesk_ticket_team": [("default_project_id", "old_default_project_id")],
+}
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    """Rename the column to keep the old value."""
+    openupgrade.rename_columns(env.cr, column_renames)

--- a/helpdesk_mgmt_project/models/helpdesk_ticket_team.py
+++ b/helpdesk_mgmt_project/models/helpdesk_ticket_team.py
@@ -5,5 +5,8 @@ class HelpdeskTeam(models.Model):
     _inherit = "helpdesk.ticket.team"
 
     default_project_id = fields.Many2one(
-        "project.project", string="Project", readonly=False
+        comodel_name="project.project",
+        string="Project",
+        readonly=False,
+        company_dependent=True,
     )


### PR DESCRIPTION
Multi-company compatibility

Example of use case with `helpdesk_mgmt_timesheet`:

- Create a team with no company defined.
- Create a project A for company A.
- Create a project B for company A.
- [Company A] In the created team we define the project A.
- [Company B] In the created team we define project B
- [Company A] We create a ticket and assign the team, project A will be defined.
- [Company B] We create a ticket and assign the team, project B will be defined.

@Tecnativa TT50251