### PR TITLE
[16.0][IMP] helpdesk_mgmt_timesheet: Show only users for company selected on ticket

### DIFF
--- a/helpdesk_mgmt_timesheet/views/helpdesk_ticket_view.xml
+++ b/helpdesk_mgmt_timesheet/views/helpdesk_ticket_view.xml
@@ -147,6 +147,7 @@
                             <field name="date_time" string="Date" required="1" />
                             <field
                                 name="user_id"
+                                domain="[('company_id','=',company_id)]"
                                 required="1"
                                 widget="many2one_avatar_user"
                             />


### PR DESCRIPTION
- Before this improvement, when you have multi-company environment and a user wants to add new timesheet, you are able to select all users for all companies that you have access to.
- This PR restrict the users that belongs to company where ticket is created.

@Tecnativa
@pedrobaeza 
TT50251