### PR TITLE
[16][FIX] helpdesk_mgmt: send confirmation mail at ticket creation from mail

### DIFF
--- a/helpdesk_mgmt/models/__init__.py
+++ b/helpdesk_mgmt/models/__init__.py
@@ -9,3 +9,4 @@ from . import res_company
 from . import res_config_settings
 from . import res_partner
 from . import res_users
+from . import mail_thread

--- a/helpdesk_mgmt/models/mail_thread.py
+++ b/helpdesk_mgmt/models/mail_thread.py
@@ -1,0 +1,16 @@
+# Copyright 2024 Akretion (https://www.akretion.com).
+# @author Kévin Roche <kevin.roche@akretion.com>
+
+from odoo import models
+
+
+class MailThread(models.AbstractModel):
+    _inherit = "mail.thread"
+
+    def _message_track_post_template(self, changes):
+        if (
+            self._context.get("default_fetchmail_server_id")
+            and self._name == "helpdesk.ticket"
+        ):
+            changes.append("stage_id")
+        return super()._message_track_post_template(changes)

--- a/helpdesk_mgmt/tests/test_helpdesk_ticket.py
+++ b/helpdesk_mgmt/tests/test_helpdesk_ticket.py
@@ -1,5 +1,7 @@
 import time
 
+from odoo.addons.test_mail.tests.test_mail_gateway import MAIL_TEMPLATE
+
 from .common import TestHelpdeskTicketBase
 
 
@@ -131,3 +133,73 @@ class TestHelpdeskTicket(TestHelpdeskTicketBase):
             }
         )
         self.assertEqual(self.new_stage, new_ticket.stage_id)
+
+    def test_create_ticket_with_mail_template(self):
+        new_stage = self.env.ref("helpdesk_mgmt.helpdesk_ticket_stage_new")
+        new_stage.team_ids = [(6, 0, [self.team_a.id])]
+        new_stage.mail_template_id = self.env.ref(
+            "helpdesk_mgmt.closed_ticket_template"
+        )
+        ticket = self.env["helpdesk.ticket"].create(
+            {
+                "name": "I'm a robot, hello",
+                "team_id": self.team_a.id,
+                "stage_id": new_stage.id,
+                "description": "Description",
+            }
+        )
+        ticket_good_reception = ticket.message_ids.filtered(
+            lambda m: m.message_type == "email"
+        )
+        self.assertIn("closed", ticket_good_reception.subject)
+
+    def test_create_ticket_from_alias_mail(self):
+        server = self.env["fetchmail.server"].create(
+            {
+                "name": "Demo server",
+                "server_type": "pop",
+                "server": "pop3.example.com",
+            }
+        )
+        self.env["mail.alias"].create(
+            {
+                "alias_name": "team_a_alias",
+                "alias_model_id": self.env.ref(
+                    "helpdesk_mgmt.model_helpdesk_ticket"
+                ).id,
+                "alias_contact": "everyone",
+                "alias_defaults": {"team_id": self.team_a.id},
+                "alias_parent_model_id": self.env.ref(
+                    "helpdesk_mgmt.model_helpdesk_ticket_team"
+                ).id,
+            }
+        )
+        new_stage = self.env.ref("helpdesk_mgmt.helpdesk_ticket_stage_new")
+        new_stage.team_ids = [(6, 0, [self.team_a.id])]
+        new_stage.mail_template_id = self.env.ref(
+            "helpdesk_mgmt.closed_ticket_template"
+        )
+        email = "from@me.com"
+
+        self.env["mail.thread"].with_context(
+            default_fetchmail_server_id=server.id
+        ).message_process(
+            server.object_id.model,
+            MAIL_TEMPLATE.format(
+                return_path=email,
+                email_from=email,
+                to="team_a_alias@example.com",
+                cc="team_aa_alias@example.com",
+                subject="Hello Ticket",
+                extra="",
+                msg_id="<test@example.com>",
+            ),
+        )
+
+        ticket = self.env["helpdesk.ticket"].search([("name", "=", "Hello Ticket")])
+        self.assertEqual(len(ticket.message_ids), 2)
+        ticket_good_reception = ticket.message_ids.filtered(
+            lambda m: m.message_type == "email" and m.email_from != email
+        )
+        self.assertEqual(len(ticket_good_reception), 1)
+        self.assertIn("closed", ticket_good_reception.subject)


### PR DESCRIPTION
When a ticket is created from a mail (via fetchmail and an alias), the confirmation mail from the first stage is not sent. 
First commit add test with the failing one. 
Second commit fix it. 
