### PR TITLE
[16.0] [FIX] helpdesk_mgmt when disabling "Required Category" in portal settings 

### DIFF
--- a/helpdesk_mgmt/controllers/main.py
+++ b/helpdesk_mgmt/controllers/main.py
@@ -70,7 +70,7 @@ class HelpdeskTicketController(http.Controller):
 
     def _prepare_submit_ticket_vals(self, **kw):
         category = http.request.env["helpdesk.ticket.category"].browse(
-            int(kw.get("category"))
+            int(kw.get("category") or 0)
         )
         company = category.company_id or http.request.env.company
         vals = {


### PR DESCRIPTION
Same fix as #610 

Tested in a 16.0 environment, the problem still occurs.

- Disable "Required Category" in helpdesk settings
   
- Create a ticket by /new/ticket with empty category



Get

File "/mnt/data/odoo-addons-dir/helpdesk_mgmt/controllers/main.py", line 73, in _prepare_submit_ticket_vals
int(kw.get("category"))
ValueError: invalid literal for int() with base 10: ''
