### PR TITLE
[15.0][IMP] helpdesk_mgmt_sale: Access tickets from the order

### DIFF
--- a/helpdesk_mgmt_sale/models/sale_order.py
+++ b/helpdesk_mgmt_sale/models/sale_order.py
@@ -1,7 +1,15 @@
-from odoo import fields, models
+from odoo import api, fields, models
 
 
 class SaleOrder(models.Model):
     _inherit = "sale.order"
 
     ticket_ids = fields.Many2many("helpdesk.ticket")
+    ticket_count = fields.Integer(
+        string="Tickets Count", compute="_compute_ticket_count", store=True
+    )
+
+    @api.depends("ticket_ids")
+    def _compute_ticket_count(self):
+        for order in self:
+            order.ticket_count = len(order.ticket_ids)

--- a/helpdesk_mgmt_sale/tests/test_helpdesk_ticket.py
+++ b/helpdesk_mgmt_sale/tests/test_helpdesk_ticket.py
@@ -20,13 +20,13 @@ class TestHelpdeskTicketSale(TransactionCase):
         cls.sale_order_1 = cls.env["sale.order"].create(
             {
                 "partner_id": cls.partner.id,
-                "ticket_ids": [(6, 0, [cls.ticket.id])],  # Adaptación a Many2many
+                "ticket_ids": [(6, 0, [cls.ticket.id])],
             }
         )
         cls.sale_order_2 = cls.env["sale.order"].create(
             {
                 "partner_id": cls.partner.id,
-                "ticket_ids": [(6, 0, [cls.ticket.id])],  # Adaptación a Many2many
+                "ticket_ids": [(6, 0, [cls.ticket.id])],
             }
         )
 

--- a/helpdesk_mgmt_sale/views/helpdesk_ticket_views.xml
+++ b/helpdesk_mgmt_sale/views/helpdesk_ticket_views.xml
@@ -15,11 +15,18 @@
                     name="action_view_sale_orders"
                     type="object"
                     class="oe_stat_button"
-                    icon="fa-ticket"
+                    icon="fa-dollar"
                 >
                     <field string="Sale Orders" name="so_count" widget="statinfo" />
                 </button>
             </xpath>
         </field>
+    </record>
+    <record id="action_helpdesk_ticket" model="ir.actions.act_window">
+        <field name="name">Tickets</field>
+        <field name="res_model">helpdesk.ticket</field>
+        <field name="view_mode">tree,form</field>
+        <field name="domain">[('sale_order_ids', 'in', active_id)]</field>
+        <field name="context">{'default_sale_order_ids': [(4, active_id)]}</field>
     </record>
 </odoo>

--- a/helpdesk_mgmt_sale/views/sale_order_views.xml
+++ b/helpdesk_mgmt_sale/views/sale_order_views.xml
@@ -15,6 +15,17 @@
                     <field name="ticket_ids" widget="many2many_tags" />
                 </group>
             </xpath>
+            <xpath expr="//div[@name='button_box']" position="inside">
+                <button
+                    name="%(action_helpdesk_ticket)d"
+                    type="action"
+                    class="btn btn-primary"
+                    icon="fa-ticket"
+                    context="{'default_sale_order_ids': [(4, id)]}"
+                >
+                    <field string="Tickets" name="ticket_count" widget="statinfo" />
+                </button>
+            </xpath>
         </field>
     </record>
 </odoo>


### PR DESCRIPTION
With the widget ‘many2many_tags’ it is not possible to click on a ticket in the order and access the form. By adding a smartbutton it is possible to access the list of tickets in the order and also consult the form for each one of them.

cc @Tecnativa TT50683

@pedrobaeza @victoralmau please review