### PR TITLE
[14.0][IMP]helpdesk_mgmt_fieldservice: review fsm_order_close_wizard security

### DIFF
--- a/helpdesk_mgmt_fieldservice/models/fsm_order.py
+++ b/helpdesk_mgmt_fieldservice/models/fsm_order.py
@@ -3,6 +3,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from odoo import fields, models
+from odoo.exceptions import AccessError
 
 
 class FSMOrder(models.Model):
@@ -13,35 +14,35 @@ class FSMOrder(models.Model):
     def action_complete(self):
         res = super().action_complete()
         if self.ticket_id:
-            open_fsm_orders_count = self.env["fsm.order"].search_count(
-                [
-                    ("ticket_id", "=", self.ticket_id.id),
-                    ("stage_id.is_closed", "=", False),
-                ]
-            )
-
-            if self.ticket_id.stage_id.closed:
-                return res
-            elif open_fsm_orders_count == 0:
-                view_id = self.env.ref(
-                    "helpdesk_mgmt_fieldservice.fsm_order_close_wizard_view_form"
-                ).id
-                return {
-                    "view_id": view_id,
-                    "view_mode": "form",
-                    "res_model": "fsm.order.close.wizard",
-                    "type": "ir.actions.act_window",
-                    "target": "new",
-                    "context": {
-                        "default_ticket_id": self.ticket_id.id,
-                        "default_team_id": self.ticket_id.team_id.id,
-                        "default_resolution": self.resolution,
-                    },
-                }
+            try:
+                self.ticket_id.check_access_rights("write")
+                self.ticket_id.check_access_rule("write")
+            except AccessError:
+                pass
             else:
-                return res
-        else:
-            return res
+                if not self.ticket_id.stage_id.closed:
+                    open_fsm_orders_count = self.env["fsm.order"].search_count(
+                        [
+                            ("ticket_id", "=", self.ticket_id.id),
+                            ("stage_id.is_closed", "=", False),
+                        ]
+                    )
+                    if open_fsm_orders_count == 0:
+                        view_id = self.env.ref(
+                            "helpdesk_mgmt_fieldservice.fsm_order_close_wizard_view_form"
+                        ).id
+                        return {
+                            "view_id": view_id,
+                            "view_mode": "form",
+                            "res_model": "fsm.order.close.wizard",
+                            "type": "ir.actions.act_window",
+                            "target": "new",
+                            "context": {
+                                "default_ticket_id": self.ticket_id.id,
+                                "default_resolution": self.resolution,
+                            },
+                        }
+        return res
 
     def action_view_order(self):
         """

--- a/helpdesk_mgmt_fieldservice/security/ir.model.access.csv
+++ b/helpdesk_mgmt_fieldservice/security/ir.model.access.csv
@@ -1,3 +1,3 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
 access_helpdesk_ticket_fsm_user,helpdesk.ticket.fsm.user,model_helpdesk_ticket,fieldservice.group_fsm_user,1,0,0,0
-access_fsm_order_close_wizard,fsm.order.close.wizard,model_fsm_order_close_wizard,fieldservice.group_fsm_user,1,1,1.0
+access_fsm_order_close_wizard,fsm.order.close.wizard,model_fsm_order_close_wizard,fieldservice.group_fsm_user_own,1,1,1.0

--- a/helpdesk_mgmt_fieldservice/tests/test_helpdesk_ticket_fsm_order.py
+++ b/helpdesk_mgmt_fieldservice/tests/test_helpdesk_ticket_fsm_order.py
@@ -119,7 +119,6 @@ class TestHelpdeskTicketFSMOrder(SavepointCase):
             action_complete_last_order["context"],
             {
                 "default_ticket_id": self.ticket_1.id,
-                "default_team_id": self.team_id.id,
                 "default_resolution": "Just another resolution",
             },
         )

--- a/helpdesk_mgmt_fieldservice/wizards/fsm_order_close_wizard.py
+++ b/helpdesk_mgmt_fieldservice/wizards/fsm_order_close_wizard.py
@@ -10,7 +10,6 @@ class FSMOrderCloseWizard(models.TransientModel):
     _description = "FSM Close - Option to Close Ticket"
 
     resolution = fields.Text(string="Resolution")
-    team_id = fields.Many2one("helpdesk.ticket.team", string="Helpdesk Team")
     stage_id = fields.Many2one("helpdesk.ticket.stage", string="Stage")
     ticket_id = fields.Many2one("helpdesk.ticket", string="Ticket")
 

--- a/helpdesk_mgmt_fieldservice/wizards/fsm_order_close_wizard.xml
+++ b/helpdesk_mgmt_fieldservice/wizards/fsm_order_close_wizard.xml
@@ -11,13 +11,7 @@
                   There is an open Ticket, would you like to update the related ticket?
               </div>
               <group>
-                  <field name="team_id" invisible="1" />
                   <field name="ticket_id" invisible="1" />
-<!--                  <field name="stage_id"-->
-<!--                         string="Ticket Stage"-->
-<!--                         required="1"-->
-<!--                         domain="[('team_ids', '=', team_id)]"-->
-<!--                         options="{'no_create': True, 'no_open': True, 'no_create_edit': True}"/>-->
                   <field
                         name="stage_id"
                         string="Ticket Stage"


### PR DESCRIPTION
Resubmitting https://github.com/OCA/helpdesk/pull/404

> This commit reviews the security rules around the fsm_order_close_wizard.
> 
> The "Complete" button on the fsm.order triggered an access error for fieldservice.group_fsm_user_own. The commit allows fieldservice.group_fsm_user_own to use the wizard as well. However, the wizard is now only shown if the user also has write permission on the specific ticket (so as to play nice with a variety of setups, including helpdesk_mgmt.group_helpdesk_user_own).
> 
> If the user has permission to write on the ticket, the wizard will be shown as before; otherwise it will simply be skipped, but the fsm.order will be closed as it should.
> 
> There's also some code cleanup on the wizard, such as removing the unused team_id field.