### PR TITLE
[16.0][IMP]helpdesk_mgmt: add 'Created Ticket' email template

### DIFF
--- a/helpdesk_mgmt/data/helpdesk_data.xml
+++ b/helpdesk_mgmt/data/helpdesk_data.xml
@@ -243,6 +243,41 @@
                 </table>
             </field>
         </record>
+
+        <record id="created_ticket_template" model="mail.template">
+            <field name="name">Helpdesk Created Ticket Notification Email</field>
+            <field name="model_id" ref="helpdesk_mgmt.model_helpdesk_ticket" />
+            <field name="email_from">{{object.company_id.partner_id.email}}</field>
+            <field
+                name="email_to"
+            >{{not object.partner_id and object.partner_email or ''}}</field>
+            <field name="subject">The ticket {{object.number}} has been created.</field>
+            <field name="partner_to">{{object.partner_id.id}}</field>
+            <field name="auto_delete" eval="False" />
+            <field name="lang">{{object.partner_id.lang}}</field>
+            <field name="body_html" type="html">
+                <div>
+                    <p>Hello <t t-out="object.partner_id.name or ''" />,</p>
+                    <p>The ticket <t
+                            t-out="object.number or 'n/a'"
+                        /> has been created.</p>
+                    <p>You can reply to this email to add information to the ticket.</p>
+                    <t t-if="object.partner_can_access()">
+                        <div style="margin: 16px 0px 16px 0px;">
+                            <a
+                                t-attf-href="{{object.get_access_link()}}"
+                                style="background-color: #875A7B; padding: 8px 16px 8px 16px; text-decoration: none; color: #fff; border-radius: 5px; font-size:13px;"
+                            >
+                                View Ticket
+                            </a>
+                        </div>
+                    </t>
+                    Thank you,<br /><br />
+                    <t t-out="user.signature" /><br />
+                </div>
+            </field>
+        </record>
+
         <!-- Sequence -->
         <record id="helpdesk_ticket_sequence" model="ir.sequence">
             <field name="name">Helpdesk Ticket Sequence</field>


### PR DESCRIPTION
New email template for newly created tickets. This email template is modelled like the already existing ones for Closed and Changed State)

This template was originally introduced in 98e5ef7f4a2e074283da3674654f662a28f02eed. As requested in https://github.com/OCA/helpdesk/pull/644#discussion_r1858034832 it has been moved into its own PR