### PR TITLE
[16.0][IMP]helpdesk_mgmt: show stage colours in portal as in normal view

### DIFF
--- a/helpdesk_mgmt/views/helpdesk_ticket_templates.xml
+++ b/helpdesk_mgmt/views/helpdesk_ticket_templates.xml
@@ -134,8 +134,15 @@
                                 </td>
                                 <td t-if="groupby != 'stage'">
                                     <span
-                                        class="badge badge-pill badge-info"
                                         title="Current stage of the ticket"
+                                        t-attf-class="badge badge-pill rounded-pill
+                                        {{
+                                            'text-bg-success' if (not ticket.unattended) and (not ticket.closed)
+                                            else 'text-bg-info' if ticket.unattended
+                                            else 'text-bg-muted' if ticket.closed
+                                            else ''
+                                        }}"
+                                        t-attf-style="color: {{'#000000' if ticket.closed else ''}};"
                                         t-esc="ticket.stage_id.name"
                                     />
                                 </td>


### PR DESCRIPTION
With this PR we restore the pill colours as they are shown in the normal Odoo tree view

_Before these changes_
![Screenshot From 2024-11-26 16-48-27](https://github.com/user-attachments/assets/d4f17c59-37b5-4e30-ba1b-8f68607e8652)

_The state is almost invisible, it shows up only after highlighting the text and it's still difficult to see_
![Screenshot From 2024-11-26 16-48-41](https://github.com/user-attachments/assets/d0aa58c9-b44f-4d3d-9403-9d4ff761b2d1)

_With these changes_
![Screenshot From 2024-11-26 16-48-16](https://github.com/user-attachments/assets/7f460b27-d757-4ff9-ba38-f0a700e80bfb)
