### PR TITLE
[17.0][FIX] helpdesk_mgmt: Correct display of avatar images in the portal

### DIFF
--- a/helpdesk_mgmt/views/helpdesk_ticket_templates.xml
+++ b/helpdesk_mgmt/views/helpdesk_ticket_templates.xml
@@ -252,7 +252,7 @@
                                     class="col d-flex align-items-center flex-grow-0 pr-3"
                                 >
                                     <img
-                                        class="rounded-circle mt-1 o_portal_contact_img"
+                                        class="o_avatar o_portal_contact_img rounded"
                                         t-att-src="image_data_uri(ticket.user_id.avatar_1024)"
                                         alt="Contact"
                                     />
@@ -290,7 +290,7 @@
                                     class="col d-flex align-items-center flex-grow-0 pr-3"
                                 >
                                     <img
-                                        class="rounded-circle mt-1 o_portal_contact_img"
+                                        class="o_avatar o_portal_contact_img rounded"
                                         t-att-src="image_data_uri(ticket.partner_id.avatar_1024)"
                                         alt="Contact"
                                     />


### PR DESCRIPTION
Correct display of avatar images in the portal

**Before**
![antes](https://github.com/user-attachments/assets/599ff8b8-fba1-4513-b60f-58831a22df8f)

**After**
![despues](https://github.com/user-attachments/assets/65ac83a0-7e6d-44e1-a151-f5b96f5c2d64)

@Tecnativa