### PR TITLE
[16.0][FIX] helpdesk_mgmt: remove redundant duplicate action

### DIFF
--- a/helpdesk_mgmt/models/helpdesk_ticket.py
+++ b/helpdesk_mgmt/models/helpdesk_ticket.py
@@ -203,10 +203,6 @@ class HelpdeskTicket(models.Model):
                 vals["assigned_date"] = now
         return super().write(vals)
 
-    def action_duplicate_tickets(self):
-        for ticket in self.browse(self.env.context["active_ids"]):
-            ticket.copy()
-
     def _prepare_ticket_number(self, values):
         seq = self.env["ir.sequence"]
         if "company_id" in values:

--- a/helpdesk_mgmt/views/helpdesk_ticket_views.xml
+++ b/helpdesk_mgmt/views/helpdesk_ticket_views.xml
@@ -382,16 +382,6 @@
             </pivot>
         </field>
     </record>
-    <record id="action_duplicate_ticket" model="ir.actions.server">
-        <field name="name">Duplicate</field>
-        <field name="model_id" ref="model_helpdesk_ticket" />
-        <field name="binding_model_id" ref="helpdesk_mgmt.model_helpdesk_ticket" />
-        <field name="binding_view_types">list</field>
-        <field name="state">code</field>
-        <field name="code">
-            action = model.action_duplicate_tickets()
-        </field>
-    </record>
     <record id="model_helpdesk_ticket_action_share" model="ir.actions.server">
         <field name="name">Share</field>
         <field name="model_id" ref="helpdesk_mgmt.model_helpdesk_ticket" />


### PR DESCRIPTION
The same result can be achieved by installing the OCA module `web_tree_duplicate`

(Duplicate duplicate, heh)