### PR TITLE
[16.0][IMP] helpdesk_ticket_close_inactive: Modified category functionality

### DIFF
--- a/helpdesk_ticket_close_inactive/README.rst
+++ b/helpdesk_ticket_close_inactive/README.rst
@@ -50,15 +50,15 @@ Configuration
 
 To configure this module, you need to:
 
-- Go to Helpdesk > Settings > Teams.
-- Select a team.
-- Enable 'Automatic closure of inactive tickets' option.
-- Set number of days to be reached before send a warning notification to
-  the partner.
-- Set warning email template or use the one provided by default.
-- Set number of days to be reached before closing ticket.
-- Set closing email template or use the one provided by default.
-- Set stages to be filtered on the domain to execute action.
+-  Go to Helpdesk > Settings > Teams.
+-  Select a team.
+-  Enable 'Automatic closure of inactive tickets' option.
+-  Set number of days to be reached before send a warning notification
+   to the partner.
+-  Set warning email template or use the one provided by default.
+-  Set number of days to be reached before closing ticket.
+-  Set closing email template or use the one provided by default.
+-  Set stages to be filtered on the domain to execute action.
 
 Bug Tracker
 ===========
@@ -81,9 +81,10 @@ Authors
 Contributors
 ------------
 
-- ``APSL-Nagarro <https://apsl.tech>``\ \_:
+-  ``APSL-Nagarro <https://apsl.tech>``\ \_:
 
-  - Miquel Alzanillas miquel.alzanillas@nagarro.com
+   -  Miquel Alzanillas miquel.alzanillas@nagarro.com
+   -  Miquel Pascual miquel.pascual@nagarro.com
 
 Maintainers
 -----------

--- a/helpdesk_ticket_close_inactive/models/helpdesk_ticket_team.py
+++ b/helpdesk_ticket_close_inactive/models/helpdesk_ticket_team.py
@@ -93,15 +93,17 @@ class HelpdeskTicketTeam(models.Model):
                 - team_id.inactive_tickets_day_limit_warning
             )
             closing_stage = team_id.closing_ticket_stage
-            warning_ticket_ids = self.env["helpdesk.ticket"].search(
-                [
-                    ("team_id", "=", team_id.id),
-                    ("stage_id", "in", ticket_stage_ids),
-                    ("category_id", "in", ticket_category_ids),
-                    ("last_stage_update", ">=", warning_limit_day_first_hour),
-                    ("last_stage_update", "<=", warning_limit_day_last_hour),
-                ]
-            )
+            search_domain = [
+                ("team_id", "=", team_id.id),
+                ("stage_id", "in", ticket_stage_ids),
+                ("last_stage_update", ">=", warning_limit_day_first_hour),
+                ("last_stage_update", "<=", warning_limit_day_last_hour),
+            ]
+
+            if ticket_category_ids:
+                search_domain.append(("category_id", "in", ticket_category_ids))
+
+            warning_ticket_ids = self.env["helpdesk.ticket"].search(search_domain)
             warning_email_ids = []
             closing_email_ids = []
             if warning_ticket_ids:
@@ -124,14 +126,18 @@ class HelpdeskTicketTeam(models.Model):
                         )
                         warning_email_ids.append(warning_email_id)
 
+            closing_ticket_domain = [
+                ("team_id", "=", team_id.id),
+                ("stage_id", "in", ticket_stage_ids),
+                ("last_stage_update", "<=", closing_limit),
+            ]
+            if ticket_category_ids:
+                closing_ticket_domain.append(("category_id", "in", ticket_category_ids))
+
             closing_ticket_ids = self.env["helpdesk.ticket"].search(
-                [
-                    ("team_id", "=", team_id.id),
-                    ("stage_id", "in", ticket_stage_ids),
-                    ("category_id", "in", ticket_category_ids),
-                    ("last_stage_update", "<=", closing_limit),
-                ]
+                closing_ticket_domain
             )
+
             if closing_ticket_ids:
                 for ticket in closing_ticket_ids:
                     context = {"stage": ticket.stage_id.name, "close": True}

--- a/helpdesk_ticket_close_inactive/readme/CONTRIBUTORS.md
+++ b/helpdesk_ticket_close_inactive/readme/CONTRIBUTORS.md
@@ -1,3 +1,4 @@
 * `APSL-Nagarro <https://apsl.tech>`_:
 
   * Miquel Alzanillas <miquel.alzanillas@nagarro.com>
+  * Miquel Pascual <miquel.pascual@nagarro.com>

--- a/helpdesk_ticket_close_inactive/static/description/index.html
+++ b/helpdesk_ticket_close_inactive/static/description/index.html
@@ -402,8 +402,8 @@ Only for development or testing purpose, do not use in production.
 <li>Go to Helpdesk &gt; Settings &gt; Teams.</li>
 <li>Select a team.</li>
 <li>Enable ‘Automatic closure of inactive tickets’ option.</li>
-<li>Set number of days to be reached before send a warning notification to
-the partner.</li>
+<li>Set number of days to be reached before send a warning notification
+to the partner.</li>
 <li>Set warning email template or use the one provided by default.</li>
 <li>Set number of days to be reached before closing ticket.</li>
 <li>Set closing email template or use the one provided by default.</li>
@@ -431,6 +431,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <ul class="simple">
 <li><tt class="docutils literal"><span class="pre">APSL-Nagarro</span> <span class="pre">&lt;https://apsl.tech&gt;</span></tt>_:<ul>
 <li>Miquel Alzanillas <a class="reference external" href="mailto:miquel.alzanillas&#64;nagarro.com">miquel.alzanillas&#64;nagarro.com</a></li>
+<li>Miquel Pascual <a class="reference external" href="mailto:miquel.pascual&#64;nagarro.com">miquel.pascual&#64;nagarro.com</a></li>
 </ul>
 </li>
 </ul>

--- a/helpdesk_ticket_close_inactive/tests/test_ticket_autoclose.py
+++ b/helpdesk_ticket_close_inactive/tests/test_ticket_autoclose.py
@@ -42,6 +42,31 @@ class TestHelpdeskTicketAutoclose(TransactionCase):
             }
         )
 
+        self.team_without_category = self.env["helpdesk.ticket.team"].create(
+            {
+                "name": "Test Team",
+                "close_inactive_tickets": True,
+                "inactive_tickets_day_limit_warning": 7,
+                "inactive_tickets_day_limit_closing": 14,
+            }
+        )
+        self.team_without_category.ticket_stage_ids = [(4, self.stage_warning.id)]
+        self.team_without_category.closing_ticket_stage = self.stage_closing
+        self.remaining_days = (
+            self.team_without_category.inactive_tickets_day_limit_closing
+            - self.team_without_category.inactive_tickets_day_limit_warning
+        )
+        self.ticket2 = self.env["helpdesk.ticket"].create(
+            {
+                "name": "Test Ticket  Without Category",
+                "team_id": self.team_without_category.id,
+                "stage_id": self.stage_warning.id,
+                "category_id": self.type_warning.id,
+                "description": "Please help me without category",
+                "last_stage_update": datetime.today() - timedelta(days=7),
+            }
+        )
+
     def test_warning_email_sent(self):
         """Test that a warning email is sent after the warning day limit is reached."""
         self.ticket.write({"last_stage_update": datetime.today() - timedelta(days=7)})
@@ -81,4 +106,14 @@ class TestHelpdeskTicketAutoclose(TransactionCase):
             str(self.remaining_days) + " days",
             sent_mail.body_html,
             "The warning email should contain the remaining days until the ticket is closed.",
+        )
+
+    def test_close_tickets_without_category(self):
+        """Test that tickets without category are closed."""
+        self.ticket2.write({"last_stage_update": datetime.today() - timedelta(days=15)})
+        self.team_without_category.close_team_inactive_tickets()
+        self.assertEqual(
+            self.ticket2.stage_id,
+            self.stage_closing,
+            "Ticket should be moved to the closing stage",
         )

--- a/helpdesk_ticket_close_inactive/views/helpdesk_ticket_team.xml
+++ b/helpdesk_ticket_close_inactive/views/helpdesk_ticket_team.xml
@@ -46,11 +46,7 @@
                             />
                         </group>
                         <group name="categories" string="Ticket Category Filter">
-                            <field
-                                name="ticket_category_ids"
-                                widget="many2many_tags"
-                                attrs="{'required': [('close_inactive_tickets', '=', True)]}"
-                            />
+                            <field name="ticket_category_ids" widget="many2many_tags" />
                         </group>
                     </group>
                 </page>


### PR DESCRIPTION
Normally you want to close tickets regardless of their category. With this imp, category field is not required anymore, so helpdesk teams without defined category will be able to automatically close every ticket, regarding of their category.

cc https://github.com/APSL HT01840

@miquelalzanillas @lbarry-apsl @BernatObrador  @peluko00 @javierobcn @ppyczko please review