### PR TITLE
[16.0][IMP] helpdesk_mgmt_timesheet: fix keyerror 'active_model'

### DIFF
--- a/helpdesk_mgmt_timesheet/wizards/hr_timesheet_switch.py
+++ b/helpdesk_mgmt_timesheet/wizards/hr_timesheet_switch.py
@@ -13,7 +13,7 @@ class HrTimesheetSwitch(models.TransientModel):
         result = super()._closest_suggestion()
         if (
             not result
-            and self.env.context["active_model"] == "helpdesk.ticket"
+            and self.env.context.get("active_model") == "helpdesk.ticket"
             and self.env.user
         ):
             result = self.env["account.analytic.line"].search(


### PR DESCRIPTION
The 'Start work' feature of the project/project_timesheet_time_control module generates the following error:

![Captura desde 2025-04-03 12-54-08](https://github.com/user-attachments/assets/0eaed793-68a2-437a-b45a-e0a24d0c01db)

These changes fixt the error

cc https://helpdesk.apsl.net/ HT01854

@miquelalzanillas @peluko00 @mpascuall @ppyczko @javierobcn @BernatObrador please review