### PR TITLE
[16.0][FIX] helpdesk_mgmt-tickets button replacement

### DIFF
--- a/helpdesk_mgmt/views/helpdesk_ticket_templates.xml
+++ b/helpdesk_mgmt/views/helpdesk_ticket_templates.xml
@@ -22,33 +22,45 @@
             </li>
         </xpath>
     </template>
+    <template id="portal_ticket_new_button">
+    <form
+            method="POST"
+            t-att-action="'/new/ticket'"
+            class="btn btn-primary btn-sm d-inline-flex align-items-center ms-auto me-3"
+        >
+        <input type="hidden" name="csrf_token" t-att-value="request.csrf_token()" />
+        <button
+                name="create_new_ticket"
+                type="action"
+                class="btn btn-primary btn-sm p-1 border-0 bg-transparent"
+            >
+        <i class="fa fa-plus me-1" /><span>New</span>
+        </button>
+    </form>
+    </template>
     <template
-        id="portal_my_home"
-        name="Portal My Home : ticket entries"
+        id="portal_docs_entry_ticket_button"
+        inherit_id="portal.portal_docs_entry"
+        priority="15"
+    >
+    <xpath expr="//t[@t-esc='title']" position="after">
+        <t t-if="url == '/my/tickets'">
+        <t t-call="helpdesk_mgmt.portal_ticket_new_button" />
+        </t>
+    </xpath>
+    </template>
+    <template
+        id="portal_my_home_tickets_entry"
         inherit_id="portal.portal_my_home"
         priority="40"
-        customize_show="True"
     >
-        <xpath expr="//div[hasclass('o_portal_docs')]" position="inside">
-            <t t-call="portal.portal_docs_entry">
-                <t t-set="title">Tickets</t>
-                <t t-set="url" t-value="'/my/tickets'" />
-                <t t-set="placeholder_count" t-value="'ticket_count'" />
-            </t>
-            <form method="POST" t-attf-action="/new/ticket">
-                <input
-                    type="hidden"
-                    name="csrf_token"
-                    t-att-value="request.csrf_token()"
-                />
-                <button
-                    name="create_new_ticket"
-                    type="action"
-                    class="btn btn-primary"
-                    style="float: right; margin-right: 0px; margin-bottom: 5px;"
-                >New Ticket</button>
-            </form>
-        </xpath>
+    <xpath expr="//div[hasclass('o_portal_docs')]" position="inside">
+        <t t-call="portal.portal_docs_entry">
+        <t t-set="title">Tickets</t>
+        <t t-set="url" t-value="'/my/tickets'" />
+        <t t-set="placeholder_count" t-value="'ticket_count'" />
+        </t>
+    </xpath>
     </template>
     <template id="portal_my_tickets" name="My Tickets">
         <t t-call="portal.portal_layout">
@@ -56,24 +68,26 @@
             <t t-call="portal.portal_searchbar">
                 <t t-set="title">Tickets</t>
             </t>
-            <form method="POST" t-attf-action="/new/ticket">
-                <button
-                    name="create_new_ticket"
-                    type="action"
-                    class="btn btn-primary"
-                    style="float: right; margin-right: 0px; margin-bottom: 5px;"
-                >New Ticket</button>
-                <input
-                    type="hidden"
-                    name="csrf_token"
-                    t-att-value="request.csrf_token()"
-                />
-            </form>
             <t t-if="not grouped_tickets">
                 <div class="alert alert-warning mt8" role="alert">
                     <p>No tickets found.</p>
                 </div>
             </t>
+            <div class="portal_my_tickets_btn d-flex justify-content-end mb-1">
+                <form method="POST" t-attf-action="/new/ticket">
+                    <button
+                        name="create_new_ticket"
+                        type="action"
+                        class="btn btn-primary"
+                        style="float: right; margin-right: 0px; margin-bottom: 5px;"
+                    >New Ticket</button>
+                    <input
+                        type="hidden"
+                        name="csrf_token"
+                        t-att-value="request.csrf_token()"
+                    />
+                </form>
+            </div>
             <t t-call="helpdesk_mgmt.portal_ticket_list" />
         </t>
     </template>


### PR DESCRIPTION
Improved placement of the ticket creation buttons on the portal pages for better usability.

-     Before: On the /my/home page, the button was located inside the Documents section and 
      Now: It has been moved to the bottom of the sidebar, below the "Edit Security Settings" link.

-     Before: On the /my/tickets page, the button was displayed to the right of the ticket list table.
      Now: It has been placed between the search bar and the table, making it more accessible.
      
Before:
![image](https://github.com/user-attachments/assets/162f9584-5bf2-4344-a8dc-785b6babdcfe)
![image](https://github.com/user-attachments/assets/854b26a5-f8ae-4036-b6d6-17f3a153f2a7)

After: 
![image](https://github.com/user-attachments/assets/579e3351-7567-4d19-8f40-5d9dca4ef8c5)
![image](https://github.com/user-attachments/assets/c2d56423-9ecd-4abb-b8c7-268094e26cd9)

Task: 4498 