### PR TITLE
[17.0][FIX] helpdesk_mgmt: Fix user_id when new ticket is created

### DIFF
--- a/helpdesk_mgmt/models/helpdesk_ticket.py
+++ b/helpdesk_mgmt/models/helpdesk_ticket.py
@@ -20,7 +20,7 @@ class HelpdeskTicket(models.Model):
     def _compute_user_id(self):
         for ticket in self:
             if not ticket.user_id and ticket.team_id:
-                ticket.user_id = ticket.team_id.alias_user_id
+                ticket.user_id = ticket.team_id.create_uid
 
     @api.model
     def _read_group_stage_ids(self, stages, domain, order):


### PR DESCRIPTION
According with this commit https://github.com/odoo/odoo/pull/138213 `alias_user_id` is removed in Odoo 17.

cc https://github.com/APSL 9141
@miquelalzanillas @lbarry-apsl @javierobcn @mpascuall @BernatObrador @ppyczko please review