### PR TITLE
[17.0][FIX] helpdesk_mgmt_timesheet: fix KeyError: 'active_model'

### DIFF
--- a/helpdesk_mgmt_timesheet/wizards/hr_timesheet_switch.py
+++ b/helpdesk_mgmt_timesheet/wizards/hr_timesheet_switch.py
@@ -13,7 +13,7 @@ class HrTimesheetSwitch(models.TransientModel):
         result = super()._closest_suggestion()
         if (
             not result
-            and self.env.context["active_model"] == "helpdesk.ticket"
+            and self.env.context.get("active_model") == "helpdesk.ticket"
             and self.env.user
         ):
             result = self.env["account.analytic.line"].search(


### PR DESCRIPTION
Related [https://github.com/OCA/helpdesk/pull/710](url)

The 'Start work' feature of the project/project_timesheet_time_control module generates error

These changes fixt the error

cc https://helpdesk.apsl.net/ HT01854

@miquelalzanillas @peluko00 @mpascuall @ppyczko @javierobcn @BernatObrador please review

