### PR TITLE
[16.0][FIX] helpdesk_mgmt: company_id must always be available for check_company

### DIFF
--- a/helpdesk_mgmt/views/helpdesk_ticket_views.xml
+++ b/helpdesk_mgmt/views/helpdesk_ticket_views.xml
@@ -169,15 +169,22 @@
                     <group name="main">
                         <group>
                             <field name="active" invisible="1" />
-                            <field name="company_id" invisible="1" />
                             <field name="team_id" options='{"always_reload": True}' />
                             <field name="user_ids" invisible="1" readonly="1" />
                             <field name="user_id" options='{"always_reload": True}' />
                             <field name="priority" widget="priority" />
+                            <!-- Because company_id is used for check_company
+                                 the field should always be present, even if invisible.
+                            -->
                             <field
                                 name="company_id"
                                 options="{'no_create': True}"
                                 groups="base.group_multi_company"
+                            />
+                            <field
+                                name="company_id"
+                                invisible="1"
+                                groups="!base.group_multi_company"
                             />
                             <field name="create_date" readonly="1" />
                             <field name="channel_id" />


### PR DESCRIPTION
In a previous commit check_company=True was added to the partner_id field. company_id was added as a hidden field to the form view. Unfortunately company_id was already present for users having multi-company rights. When updating modules based on helpdesk_mgmt this leads to errors. This should not happen because of the hidden field, but adding it this way prevents the error.