### PR TITLE
[17.0][FIX] helpdesk_mgmt: Use t-field="ticket.partner_id" to avoid access errors in portal

### DIFF
--- a/helpdesk_mgmt/views/helpdesk_ticket_templates.xml
+++ b/helpdesk_mgmt/views/helpdesk_ticket_templates.xml
@@ -121,7 +121,7 @@
                         <t t-foreach="tickets" t-as="ticket">
                             <tr>
                                 <td class="text-left">
-                                    <span t-esc="ticket.partner_id.name" />
+                                    <span t-field="ticket.partner_id" />
                                 </td>
                                 <td class="text-left">
                                     <span t-esc="ticket.number" />


### PR DESCRIPTION
FWP from 16.0: https://github.com/OCA/helpdesk/pull/761

Use `t-field="ticket.partner_id"` to avoid access errors in portal

Example use case:
- Create a ticket to partner Marc Demo
- Add as follower a portal user (Joel Wills)
- Login to the portal with the user Joel Wills and go to the ticket list page
- No error will be displayed and the partner's name will be displayed.

Please @pedrobaeza and @pilarvargas-tecnativa can you review it?

@Tecnativa TT56075