### PR TITLE
[18.0][FIX] helpdesk_mgmt: Don't fail on category not required

### DIFF
--- a/helpdesk_mgmt/controllers/main.py
+++ b/helpdesk_mgmt/controllers/main.py
@@ -70,7 +70,7 @@ class HelpdeskTicketController(http.Controller):
 
     def _prepare_submit_ticket_vals(self, **kw):
         category = http.request.env["helpdesk.ticket.category"].browse(
-            int(kw.get("category"))
+            int(kw.get("category") or 0)
         )
         company = category.company_id or http.request.env.company
         vals = {


### PR DESCRIPTION
Forward-port of #767 and #768

Steps to reproduce:

- Go to Helpdesk > Configuration > Settings.
- Uncheck "Required Category" and save.
- Go to portal page (/my) and click on "New Ticket".
- Fill all the required data except "Category".
- Press on "Submit Ticket".

An error will raise:

```
File "./helpdesk_mgmt/controllers/main.py", line 106, in submit_ticket
  vals = self._prepare_submit_ticket_vals(**kw)
File "./helpdesk_custom_esment/controllers/main.py", line 41, in _prepare_submit_ticket_vals
  vals = super()._prepare_submit_ticket_vals(**kw)
File "./helpdesk_mgmt_timesheet/controllers/main.py", line 11, in _prepare_submit_ticket_vals
  vals = super(CustomHelpdeskTicketController, self)._prepare_submit_ticket_vals(
File "./helpdesk_mgmt/controllers/main.py", line 73, in _prepare_submit_ticket_vals
  int(kw.get("category", 0))
ValueError: invalid literal for int() with base 10: ''
```

As there's no value set there. The solution is to make the code resilient for empty values in that field.

@Tecnativa TT56656