### PR TITLE
[17.0][IMP] helpdesk_mgmt: Fine-tuning of the Kanban view for helpdesk.ticket

### DIFF
--- a/helpdesk_mgmt/views/helpdesk_ticket_views.xml
+++ b/helpdesk_mgmt/views/helpdesk_ticket_views.xml
@@ -171,7 +171,11 @@
                             <field name="active" invisible="1" />
                             <field name="team_id" options='{"always_reload": True}' />
                             <field name="user_ids" invisible="1" readonly="1" />
-                            <field name="user_id" options='{"always_reload": True}' />
+                            <field
+                                name="user_id"
+                                options='{"always_reload": True}'
+                                widget="many2one_avatar_user"
+                            />
                             <field name="priority" widget="priority" />
                             <field
                                 name="company_id"
@@ -272,6 +276,9 @@
                 <field name="name" />
                 <field name="partner_name" />
                 <field name="user_id" />
+                <field name="user_ids" />
+                <field name="team_id" />
+                <field name="category_id" />
                 <field name="sequence" />
                 <field name="color" />
                 <field name="stage_id" />
@@ -315,6 +322,13 @@
                             <div class="o_kanban_record_top">
                                 <div class="o_kanban_record_headings">
                                     <field name="name" />
+                                    <span
+                                        t-if="record.category_id.value"
+                                        class="o_text_overflow text-muted"
+                                        style="display: block; margin-top: 4px;"
+                                    >
+                                        <field name="category_id" />
+                                    </span>
                                     <field
                                         name="tag_ids"
                                         widget="many2many_tags"
@@ -342,13 +356,9 @@
                                         widget="state_selection"
                                     />
                                     <field name="activity_state" invisible="1" />
-                                    <img
-                                        t-att-src="kanban_image('res.users', 'image_128', record.user_id.raw_value)"
-                                        t-att-title="record.user_id.value"
-                                        width="24"
-                                        height="24"
-                                        class="oe_kanban_avatar o_image_24_cover float-right"
-                                        t-att-alt="record.user_id.value"
+                                    <field
+                                        name="user_id"
+                                        widget="many2one_avatar_user"
                                     />
                                 </div>
                             </div>


### PR DESCRIPTION
- Use the `many2one_avatar_user` widget to distinguish between users with profile images and those without. This widget displays a colored circle with the user's initial instead of showing a blank image when no profile picture is set.

- Add the category field to the Kanban view.

TT56895
@Tecnativa @pedrobaeza @victoralmau could you please review this?

![image](https://github.com/user-attachments/assets/f4ae2e69-78b1-489f-831e-13884eaeaca7)
