### PR TITLE
[17.0][IMP] helpdesk_mgmt: Set default stage_id when creating a ticket to e…

### DIFF
--- a/helpdesk_mgmt/models/helpdesk_ticket.py
+++ b/helpdesk_mgmt/models/helpdesk_ticket.py
@@ -167,6 +167,12 @@ class HelpdeskTicket(models.Model):
                 team = self.env["helpdesk.ticket.team"].browse([vals["team_id"]])
                 if team.company_id:
                     vals["company_id"] = team.company_id.id
+                if "stage_id" not in vals:
+                    # Ensure that stage_id is set before creating the ticket
+                    # so that the field is tracked correctly
+                    # and notifications can be sent by email
+                    # if a mail template is configured
+                    vals["stage_id"] = team._get_applicable_stages()[:1].id
             # Automatically set default e-mail channel when created from the
             # fetchmail cron task
             if self.env.context.get("fetchmail_cron_running") and not vals.get(


### PR DESCRIPTION
…nsure tracking and notifications

**Steps to Reproduce:**

- Configure a team with an alias.
- Set a mail template on the first stage.
- Send an email to this alias.
- The ticket is created and the stage is assigned, but the mail template is not sent.

**Expected Behavior:**
After this commit, the mail is correctly sent when the ticket is created from an incoming email.

**Technical Background:**
Odoo only calls the _track_post_template_finalize function when a field with tracking=True is changed during record creation. However, stage_id is a computed field and does not have a default value, so it is not included in the tracked fields, it is computed after the record is created:
https://github.com/odoo/odoo/blob/3be83d363786526fe470e41122169e594b5467fb/addons/mail/models/mail_thread.py#L299-L304

TT56912
@Tecnativa @pedrobaeza @victoralmau could you please review this?