### PR TITLE
[17.0][FIX] helpdesk_mgmt_timesheet: Incorrect filter definition

### DIFF
--- a/helpdesk_mgmt_timesheet/views/helpdesk_ticket_view.xml
+++ b/helpdesk_mgmt_timesheet/views/helpdesk_ticket_view.xml
@@ -24,7 +24,7 @@
                     name="with_activity_today"
                     string="With activity today"
                     groups="hr_timesheet.group_hr_timesheet_user"
-                    domain="[('last_timesheet_activity', '=', datetime.datetime.today())]"
+                    domain="[('last_timesheet_activity', '&gt;', context_today() - datetime.timedelta(days=1)), ('last_timesheet_activity', '&lt;=', context_today())]"
                 />
                 <separator />
             </filter>


### PR DESCRIPTION
With the filter "With activity today" in the helpdesk tickets view, you get the following error:

```
Error: Failed to evaluate the domain: [("last_timesheet_activity", "=", datetime.datetime.today())].
    fnValue is not a function
```

Because the definition is incorrect.

Now it has a correct definition.

@Tecnativa 