### PR TITLE
[16.0][FIX] _primary_email

### DIFF
--- a/helpdesk_mgmt/models/helpdesk_ticket.py
+++ b/helpdesk_mgmt/models/helpdesk_ticket.py
@@ -10,6 +10,7 @@ class HelpdeskTicket(models.Model):
     _order = "priority desc, sequence, number desc, id desc"
     _mail_post_access = "read"
     _inherit = ["mail.thread.cc", "mail.activity.mixin", "portal.mixin"]
+    _primary_email = "partner_email"
 
     @api.depends("team_id")
     def _compute_stage_id(self):


### PR DESCRIPTION
This PR fixes a critical issue with email loop detection in the helpdesk.ticket model by adding the missing _primary_email attribute, which prevents spam and duplicate ticket creation through email aliases.

**Problem**

The helpdesk.ticket model was missing the _primary_email attribute, causing the following issues:

1. No spam protection: The system couldn't detect when the same email address was creating multiple tickets in a short time period
2. Duplicate tickets: Multiple tickets could be created from the same email address without any loop detection
3. Log warnings: The system was logging "Primary email missing on helpdesk.ticket" messages
4. Inconsistent behavior: Different behavior between Community and Enterprise versions

**Root Cause**

The _detect_loop_sender_domain method in mail.thread relies on the _primary_email attribute to:

- Create search domains for detecting duplicate records
- Prevent spam by monitoring email frequency
- Associate incoming emails with existing records

When _primary_email is not defined, the method returns None, effectively disabling loop detection for that model.