### PR TITLE
[16.0][FIX] helpdesk_mgmt: Typo in translate attribute

### DIFF
--- a/helpdesk_mgmt/models/helpdesk_ticket_tag.py
+++ b/helpdesk_mgmt/models/helpdesk_ticket_tag.py
@@ -7,7 +7,7 @@ class HelpdeskTicketTag(models.Model):
     _order = "sequence,id"
 
     sequence = fields.Integer(default=10)
-    name = fields.Char(translatable=True)
+    name = fields.Char(translate=True)
     color = fields.Integer(string="Color Index")
     active = fields.Boolean(default=True)
     company_id = fields.Many2one(


### PR DESCRIPTION
Fixup of 4b3fcb4b188168ff6558f963c5accb5834077915.

@Tecnativa 