### PR TITLE
[17.0][IMP] helpdesk_mgmt: splits the Helpdesk ticket menu into two submenus.

### DIFF
--- a/helpdesk_mgmt/views/helpdesk_ticket_menu.xml
+++ b/helpdesk_mgmt/views/helpdesk_ticket_menu.xml
@@ -13,6 +13,12 @@
         <field name="res_model">helpdesk.ticket</field>
         <field name="view_mode">tree,kanban,form,pivot</field>
     </record>
+    <record id="helpdesk_my_tickets_action" model="ir.actions.act_window">
+        <field name="name">My Tickets</field>
+        <field name="res_model">helpdesk.ticket</field>
+        <field name="view_mode">kanban,tree,pivot,form</field>
+        <field name="domain">[('user_id', '=', uid)]</field>
+    </record>
     <record id="helpdesk_ticket_reporting_action" model="ir.actions.act_window">
         <field name="name">Reporting</field>
         <field name="type">ir.actions.act_window</field>
@@ -68,8 +74,21 @@
         id="helpdesk_ticket_menu"
         name="Tickets"
         parent="helpdesk_ticket_main_menu"
-        action="helpdesk_ticket_action"
         sequence="10"
+    />
+    <menuitem
+        id="helpdesk_own_ticket_menu"
+        name="My Tickets"
+        parent="helpdesk_ticket_menu"
+        action="helpdesk_my_tickets_action"
+        sequence="10"
+    />
+    <menuitem
+        id="helpdesk_all_ticket_menu"
+        name="All Tickets"
+        parent="helpdesk_ticket_menu"
+        action="helpdesk_ticket_action"
+        sequence="20"
     />
     <menuitem
         id="helpdesk_ticket_reporting_menu"


### PR DESCRIPTION
By default, the Helpdesk Ticket menu displays all tickets a user can see. With this `IMP`, the menu is split into two submenus for better segmentation and usability.
- "My Tickets": Displays tickets assigned to the current user.
<img width="1054" height="307" alt="image" src="https://github.com/user-attachments/assets/2ce14f34-d7a2-43cc-88b2-0f022d3c6061">
- "All Tickets": Displays all tickets.
<img width="1899" height="497" alt="image" src="https://github.com/user-attachments/assets/2d0f4c20-6165-4f2b-97ce-0721d934028a" />

