### PR TITLE
[17.0][FIX] helpdesk_ticket_partner_response: fix sending tickets with attachments from portal

### DIFF
--- a/helpdesk_ticket_partner_response/controllers/mail.py
+++ b/helpdesk_ticket_partner_response/controllers/mail.py
@@ -76,7 +76,7 @@ class HelpdeskCustomerResponse(PortalChatter):
             # verification in mail message
             record = request.env[res_model].browse(res_id)
             message_values = {"res_id": res_id, "model": res_model}
-            attachments = record._message_post_process_attachments(
+            attachments = record._process_attachments_for_post(
                 [], attachment_ids, message_values
             )
 


### PR DESCRIPTION
This PR fixes sending helpdesk tickets from portal containing attachments. 

**Problem**:

Sending a helpdesk ticket from portal containing an attachment raises exception that method _message_post_process_attachments(...) is not known.

**Root Cause**:

Mentioned method got renamed in odoo upstream for v17. The rename happened in odoo commit 1c240f11df6cf19aea9a3e5c58314ddaef3cf2ce back in Nov 2022.

The signature of the method did not change. Testing locally, this patch fixes the issue.

commit 1c240f11df6cf19aea9a3e5c58314ddaef3cf2ce
Date:   Mon Nov 28 09:53:25 2022 +0000

diff --git a/addons/account/models/account_move.py b/addons/account/models/account_move.py
index 8791cf0192dd..d13a23d28621 100644
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -3998,7 +3998,7 @@ class AccountMove(models.Model):
         render_context['subtitles'] = subtitles
         return render_context
 
\-    def _message_post_process_attachments(self, attachments, attachment_ids, message_values):
\+    def _process_attachments_for_post(self, attachments, attachment_ids, message_values):
        