### PR TITLE
[17.0][FIX] helpdesk_mgmt: Fix hierarchical categories in portal view

### DIFF
--- a/helpdesk_mgmt/views/helpdesk_ticket_templates.xml
+++ b/helpdesk_mgmt/views/helpdesk_ticket_templates.xml
@@ -98,7 +98,7 @@
                                 >Tickets in category:</em>
                                 <span
                                     class="text-truncate"
-                                    t-field="tickets[0].sudo().category_id.name"
+                                    t-field="tickets[0].sudo().category_id.complete_name"
                                 />
                             </th>
                             <th t-if="groupby == 'stage'">
@@ -134,7 +134,7 @@
                                     </a>
                                 </td>
                                 <td t-if="groupby != 'category'">
-                                    <span t-esc="ticket.category_id.name" />
+                                    <span t-esc="ticket.category_id.complete_name" />
                                 </td>
                                 <td t-if="groupby != 'stage'">
                                     <span
@@ -468,7 +468,7 @@
                             <option value="" />
                             <t t-foreach="categories" t-as="cat">
                                 <option t-attf-value="#{cat.id}">
-                                    <t t-esc="cat.name" />
+                                    <t t-esc="cat.complete_name" />
                                 </option>
                             </t>
                         </select>


### PR DESCRIPTION
When using portal feature, the hierarchical categories were not displayed correctly. This fixes the issue by ensuring that the complete name of the category is shown.
 - BEFORE
<img width="787" height="394" alt="imagen" src="https://github.com/user-attachments/assets/e6114bc3-2558-4c3c-934d-57a3c850217a" />
<img width="1338" height="237" alt="imagen" src="https://github.com/user-attachments/assets/a9fe8652-7605-4d18-9bf9-3a5abf742dfd" />
<img width="1345" height="276" alt="imagen" src="https://github.com/user-attachments/assets/f40e8b21-b321-4a30-9abc-14a8840795c6" />
 - AFTER
<img width="874" height="518" alt="imagen" src="https://github.com/user-attachments/assets/98313c88-1ba5-4495-b495-b219d1ca6b1c" />
<img width="1346" height="234" alt="imagen" src="https://github.com/user-attachments/assets/5ce66a5f-4ada-47b0-82cd-df7ea12a91f4" />
<img width="1363" height="283" alt="imagen" src="https://github.com/user-attachments/assets/659fc523-fd5b-4ca4-9723-b1469bb4a18d" />
