### PR TITLE
[17.0] [IMP] helpdesk_mgmt: categories visibility in portal

### DIFF
--- a/helpdesk_mgmt/controllers/main.py
+++ b/helpdesk_mgmt/controllers/main.py
@@ -46,7 +46,7 @@ class HelpdeskTicketController(http.Controller):
         company = request.env.company
         category_model = http.request.env["helpdesk.ticket.category"]
         categories = category_model.with_company(company.id).search(
-            [("active", "=", True)]
+            [("active", "=", True), ("show_in_portal", "=", True)]
         )
         email = http.request.env.user.email
         name = http.request.env.user.name

--- a/helpdesk_mgmt/models/helpdesk_ticket_category.py
+++ b/helpdesk_mgmt/models/helpdesk_ticket_category.py
@@ -36,6 +36,7 @@ class HelpdeskCategory(models.Model):
     complete_name = fields.Char(
         compute="_compute_complete_name", store=True, recursive=True
     )
+    show_in_portal = fields.Boolean(default=True)
 
     @api.depends("name", "parent_id.complete_name")
     def _compute_complete_name(self):

--- a/helpdesk_mgmt/views/helpdesk_ticket_category_views.xml
+++ b/helpdesk_mgmt/views/helpdesk_ticket_category_views.xml
@@ -10,6 +10,11 @@
                     name="inactive"
                     domain="[('active','=',False)]"
                 />
+                <filter
+                    string="Displayed in portal"
+                    name="show_in_portal"
+                    domain="[('show_in_portal','=',True)]"
+                />
                 <separator />
                 <field name="name" filter_domain="[('name', 'ilike', self)]" />
                 <field name="parent_id" />
@@ -54,6 +59,7 @@
                     <group name="main">
                         <field name="parent_id" />
                         <field name="child_id" widget="many2many_tags" readonly="1" />
+                        <field name="show_in_portal" widget="boolean_toggle" />
                         <field name="company_id" groups="base.group_multi_company" />
                         <field name="active" invisible="1" />
                     </group>
@@ -69,6 +75,7 @@
                 <field name="sequence" widget="handle" />
                 <field name="name" />
                 <field name="parent_id" />
+                <field name="show_in_portal" widget="boolean_toggle" />
                 <field
                     name="company_id"
                     optional="hide"


### PR DESCRIPTION
This IMP introduce a category filter to control which one are displayed in helpdesk portal.
<img width="1363" height="289" alt="imagen" src="https://github.com/user-attachments/assets/75df7d9e-6cd9-4fd9-9e10-a4849df808a1" />
<img width="552" height="334" alt="imagen" src="https://github.com/user-attachments/assets/c35f3e30-795a-46a7-8213-d6c86b834d9c" />
