### PR TITLE
[17.0] [IMP] Set default assigned user by category for tickets created from portal

### DIFF
--- a/helpdesk_mgmt/models/helpdesk_ticket.py
+++ b/helpdesk_mgmt/models/helpdesk_ticket.py
@@ -205,6 +205,16 @@ class HelpdeskTicket(models.Model):
                 )
                 if channel_email_id:
                     vals["channel_id"] = channel_email_id.id
+            if self.env.user.share and vals.get("category_id"):
+                category = self.env["helpdesk.ticket.category"].browse(
+                    vals["category_id"]
+                )
+                if (
+                    category.default_partner_id
+                    and not self.env.company.helpdesk_mgmt_portal_select_team
+                ):
+                    vals["user_id"] = category.default_partner_id.id
+
         return super().create(vals_list)
 
     def copy(self, default=None):

--- a/helpdesk_mgmt/models/helpdesk_ticket_category.py
+++ b/helpdesk_mgmt/models/helpdesk_ticket_category.py
@@ -37,6 +37,11 @@ class HelpdeskCategory(models.Model):
         compute="_compute_complete_name", store=True, recursive=True
     )
     show_in_portal = fields.Boolean(default=True)
+    default_partner_id = fields.Many2one(
+        comodel_name="res.users",
+        string="Default Assigned Portal User",
+        domain=[("share", "=", False)],
+    )
 
     @api.depends("name", "parent_id.complete_name")
     def _compute_complete_name(self):

--- a/helpdesk_mgmt/tests/test_helpdesk_portal.py
+++ b/helpdesk_mgmt/tests/test_helpdesk_portal.py
@@ -232,3 +232,105 @@ class TestHelpdeskPortal(TestHelpdeskPortalBase):
         # check that both files are public (access_token is set)
         self.assertTrue(attachment_ids[0].access_token)
         self.assertTrue(attachment_ids[1].access_token)
+
+    def test_portal_ticket_user_assignment_logic(self):
+        """Test the behavior of user
+        assignment when a ticket is created from the portal."""
+
+        portal_user = new_test_user(
+            self.env,
+            login="test_portal_user",
+            groups="base.group_portal",
+        )
+        default_user = self.env["res.users"].create(
+            {
+                "name": "Default User",
+                "login": "default_user",
+                "email": "default@example.com",
+                "groups_id": [
+                    (6, 0, [self.env.ref("helpdesk_mgmt.group_helpdesk_user").id])
+                ],
+            }
+        )
+        category_with_default = self.env["helpdesk.ticket.category"].create(
+            {
+                "name": "Category with Default Partner",
+                "default_partner_id": default_user.id,
+            }
+        )
+        ticket_with_default_user = (
+            self.env["helpdesk.ticket"]
+            .with_user(portal_user)
+            .sudo()
+            .create(
+                {
+                    "name": "Ticket with default user",
+                    "category_id": category_with_default.id,
+                    "description": "",
+                }
+            )
+        )
+        category_without_default = self.env["helpdesk.ticket.category"].create(
+            {
+                "name": "Category without default user",
+            }
+        )
+        ticket_without_default_user = (
+            self.env["helpdesk.ticket"]
+            .with_user(portal_user)
+            .sudo()
+            .create(
+                {
+                    "name": "Ticket without default user",
+                    "category_id": category_without_default.id,
+                    "description": "",
+                }
+            )
+        )
+        self.assertEqual(
+            ticket_with_default_user.user_id,
+            default_user,
+            "Ticket should be assigned to the default user.",
+        )
+
+        self.assertEqual(
+            ticket_without_default_user.user_id,
+            portal_user,
+            "Ticket should be assigned to the portal user.",
+        )
+
+        ticket_by_internal_user = (
+            self.env["helpdesk.ticket"]
+            .with_user(default_user)
+            .create(
+                {
+                    "name": "Ticket by internal user",
+                    "category_id": category_with_default.id,
+                    "description": "",
+                }
+            )
+        )
+        self.assertEqual(
+            ticket_by_internal_user.user_id,
+            default_user,
+            "Ticket should be assigned to the internal user.",
+        )
+
+        self.env.company.helpdesk_mgmt_portal_select_team = True
+        ticket_with_option_enabled = (
+            self.env["helpdesk.ticket"]
+            .with_user(portal_user)
+            .sudo()
+            .create(
+                {
+                    "name": "Ticket with portal team option enabled",
+                    "category_id": category_with_default.id,
+                    "description": "",
+                }
+            )
+        )
+        self.assertEqual(
+            ticket_with_option_enabled.user_id,
+            portal_user,
+            "Ticket should be assigned to the portal user",
+        )

--- a/helpdesk_mgmt/views/helpdesk_ticket_category_views.xml
+++ b/helpdesk_mgmt/views/helpdesk_ticket_category_views.xml
@@ -61,6 +61,10 @@
                         <field name="child_id" widget="many2many_tags" readonly="1" />
                         <field name="show_in_portal" widget="boolean_toggle" />
                         <field name="company_id" groups="base.group_multi_company" />
+                        <field
+                            name="default_partner_id"
+                            widget="many2one_avatar_user"
+                        />
                         <field name="active" invisible="1" />
                     </group>
                 </sheet>
@@ -81,6 +85,7 @@
                     optional="hide"
                     groups="base.group_multi_company"
                 />
+                <field name="default_partner_id" widget="many2one_avatar_user" />
             </tree>
         </field>
     </record>

--- a/helpdesk_mgmt/views/helpdesk_ticket_templates.xml
+++ b/helpdesk_mgmt/views/helpdesk_ticket_templates.xml
@@ -218,8 +218,8 @@
                                 />
                             </div>
                             <div t-if="ticket.closed_date">
-                                    <strong>Close Date:</strong>
-                                    <span
+                                <strong>Close Date:</strong>
+                                <span
                                     t-field="ticket.closed_date"
                                     t-options='{"widget": "datetime"}'
                                 />
@@ -264,7 +264,7 @@
                                         <span class="fa fa-download" />
                                         <span t-esc="f.name" />
                                     </a>
-                                <br />
+                                    <br />
                                 </t>
                             </t>
                         </div>


### PR DESCRIPTION
In the portal view, automatically assign the user specified in the Helpdesk configuration by default, but only when the ticket is created through the portal by a portal user. The list of assignable users must be limited to internal users only.
<img width="1440" height="311" alt="imagen" src="https://github.com/user-attachments/assets/6b41ba94-9736-49f4-aab1-18f963c1ec5d" />
<img width="1309" height="367" alt="imagen" src="https://github.com/user-attachments/assets/78c721c7-488b-482e-9882-4eac91acc82b" />
<img width="1305" height="370" alt="imagen" src="https://github.com/user-attachments/assets/22acff23-fd7b-4879-a8c4-13dac0e66aa8" />
<img width="1896" height="527" alt="imagen" src="https://github.com/user-attachments/assets/309c4d07-a24a-427f-b217-9c60e839082c" />
