### PR TITLE
[18.0] [IMP] `helpdesk_mgmt`: add action url paths

### DIFF
--- a/helpdesk_mgmt/views/helpdesk_ticket_menu.xml
+++ b/helpdesk_mgmt/views/helpdesk_ticket_menu.xml
@@ -6,54 +6,63 @@
         <field name="type">ir.actions.act_window</field>
         <field name="res_model">helpdesk.ticket.team</field>
         <field name="view_mode">kanban,list,form,pivot</field>
+        <field name="path">helpdesk-dashboard</field>
     </record>
     <record id="helpdesk_ticket_action" model="ir.actions.act_window">
         <field name="name">Tickets</field>
         <field name="type">ir.actions.act_window</field>
         <field name="res_model">helpdesk.ticket</field>
         <field name="view_mode">list,kanban,form,pivot</field>
+        <field name="path">helpdesk-tickets</field>
     </record>
     <record id="helpdesk_my_tickets_action" model="ir.actions.act_window">
         <field name="name">My Tickets</field>
         <field name="res_model">helpdesk.ticket</field>
         <field name="view_mode">kanban,list,pivot,form</field>
         <field name="domain">[('user_id', '=', uid)]</field>
+        <field name="path">my-helpdesk-tickets</field>
     </record>
     <record id="helpdesk_ticket_reporting_action" model="ir.actions.act_window">
         <field name="name">Reporting</field>
         <field name="type">ir.actions.act_window</field>
         <field name="res_model">helpdesk.ticket</field>
         <field name="view_mode">pivot,graph</field>
+        <field name="path">helpdesk-report</field>
     </record>
     <record id="helpdesk_ticket_channel_action" model="ir.actions.act_window">
         <field name="name">Channels</field>
         <field name="type">ir.actions.act_window</field>
         <field name="res_model">helpdesk.ticket.channel</field>
         <field name="view_mode">list,form</field>
+        <field name="path">helpdesk-channels</field>
     </record>
     <record id="helpdesk_ticket_category_action" model="ir.actions.act_window">
         <field name="name">Categories</field>
         <field name="type">ir.actions.act_window</field>
         <field name="res_model">helpdesk.ticket.category</field>
         <field name="view_mode">list,form</field>
+        <field name="path">helpdesk-categories</field>
     </record>
     <record id="helpdesk_ticket_team_action" model="ir.actions.act_window">
         <field name="name">Teams</field>
         <field name="type">ir.actions.act_window</field>
         <field name="res_model">helpdesk.ticket.team</field>
         <field name="view_mode">list,form</field>
+        <field name="path">helpdesk-teams</field>
     </record>
     <record id="helpdesk_ticket_stage_action" model="ir.actions.act_window">
         <field name="name">Stages</field>
         <field name="type">ir.actions.act_window</field>
         <field name="res_model">helpdesk.ticket.stage</field>
         <field name="view_mode">list,form</field>
+        <field name="path">helpdesk-stages</field>
     </record>
     <record id="helpdesk_ticket_tag_action" model="ir.actions.act_window">
         <field name="name">Ticket Tags</field>
         <field name="type">ir.actions.act_window</field>
         <field name="res_model">helpdesk.ticket.tag</field>
         <field name="view_mode">list,form</field>
+        <field name="path">helpdesk-tags</field>
     </record>
     <!-- Menus -->
     <menuitem


### PR DESCRIPTION
These form nicer URLs in backend actions.

The `helpdesk-mgmt-` prefix is not ideal, but paths must be unique and so this is to avoid conflicts with Odoo's `helpdesk` module