### PR TITLE
[16.0][FIX] helpdesk_mgmt: Restrict ticket tag deletion

### DIFF
--- a/helpdesk_mgmt/models/helpdesk_ticket.py
+++ b/helpdesk_mgmt/models/helpdesk_ticket.py
@@ -82,7 +82,9 @@ class HelpdeskTicket(models.Model):
     closed_date = fields.Datetime()
     closed = fields.Boolean(related="stage_id.closed")
     unattended = fields.Boolean(related="stage_id.unattended", store=True)
-    tag_ids = fields.Many2many(comodel_name="helpdesk.ticket.tag", string="Tags")
+    tag_ids = fields.Many2many(
+        comodel_name="helpdesk.ticket.tag", string="Tags", ondelete="restrict"
+    )
     company_id = fields.Many2one(
         comodel_name="res.company",
         string="Company",


### PR DESCRIPTION
If you have a ticket tag assigned in several tickets, and you remove the tag, it's lost on all the tickets you had it assigned, which leads to data lost.

Let's restrict the deletion of the tag if used through the standard mechanism in `ondelete` field attribute.

@Tecnativa TT57697