### PR TITLE
[18.0][FIX] helpdesk_mgmt: Helpdesk's portal tile must be always visible

### DIFF
--- a/helpdesk_mgmt/views/helpdesk_ticket_templates.xml
+++ b/helpdesk_mgmt/views/helpdesk_ticket_templates.xml
@@ -38,6 +38,9 @@
         inherit_id="portal.portal_docs_entry"
         primary="True"
     >
+        <xpath expr="//t[@t-set='force_show']" position="attributes">
+            <attribute name="t-value">True</attribute>
+        </xpath>
         <xpath expr="//span[@t-out='title']" position="after">
             <t t-call="helpdesk_mgmt.portal_ticket_new_button">
                 <t t-set="_btn_classes" t-value="'btn-sm'" />


### PR DESCRIPTION
That's way, the portal's user can use the "New" button in the tile but also in the header if the user choose to browse existing tickets.

<img width="1318" height="475" alt="image" src="https://github.com/user-attachments/assets/08926ac7-24b8-4942-a209-9285f2cb6326" />

<img width="883" height="373" alt="image" src="https://github.com/user-attachments/assets/3b09775f-eb67-47cf-a2e7-449a44be670d" />


Fixing Issue #820