### PR TITLE
[16.0][IMP] helpdesk_mgmt: Improve usage of Kanban State

### DIFF
--- a/helpdesk_mgmt/models/helpdesk_ticket.py
+++ b/helpdesk_mgmt/models/helpdesk_ticket.py
@@ -203,6 +203,8 @@ class HelpdeskTicket(models.Model):
                     vals["closed_date"] = now
             if vals.get("user_id"):
                 vals["assigned_date"] = now
+            if "stage_id" in vals and "kanban_state" not in vals:
+                vals["kanban_state"] = False
         return super().write(vals)
 
     def action_duplicate_tickets(self):

--- a/helpdesk_mgmt/views/helpdesk_ticket_views.xml
+++ b/helpdesk_mgmt/views/helpdesk_ticket_views.xml
@@ -90,6 +90,17 @@
                     domain="[('activity_ids.date_deadline', '&gt;', context_today().strftime('%Y-%m-%d'))
                   ]"
                 />
+                <separator />
+                <filter
+                    string="Blocked"
+                    name="kanban_state_blocked"
+                    domain="[('kanban_state', '=', 'blocked')]"
+                />
+                <filter
+                    string="Ready for next stage"
+                    name="kanban_state_done"
+                    domain="[('kanban_state', '=', 'done')]"
+                />
                 <group expand="0" string="Group By">
                     <filter
                         string="Partner"
@@ -120,6 +131,12 @@
                         name="group_stage"
                         domain="[]"
                         context="{'group_by':'stage_id'}"
+                    />
+                    <filter
+                        string="State"
+                        name="group_state"
+                        domain="[]"
+                        context="{'group_by':'kanban_state'}"
                     />
                     <filter
                         string="Tag"
@@ -158,9 +175,14 @@
                     />
                     <div class="oe_button_box" name="button_box">
                     </div>
-                    <div class="oe_title">
-                        <h1 class="oe_title">
+                    <div class="oe_title pe-0 w-100 mw-100" name="title">
+                        <h1 class="d-flex flex-row justify-content-between">
                             <field name="number" />
+                            <field
+                                name="kanban_state"
+                                class="d-flex align-items-center"
+                                widget="state_selection"
+                            />
                         </h1>
                         <h2 class="o_row">
                             <field name="name" />
@@ -228,6 +250,12 @@
                 <field name="priority" widget="priority" />
                 <field name="sequence" widget="handle" />
                 <field name="number" decoration-bf="1" />
+                <field
+                    name="kanban_state"
+                    string="State"
+                    widget="state_selection"
+                    options="{'hide_label': 1}"
+                />
                 <field name="name" />
                 <field name="partner_id" optional="hide" widget="many2one_avatar" />
                 <field name="partner_name" optional="show" />


### PR DESCRIPTION
Before this change, Kanban States was only showed on Kanban View and when we changed state, the value was not overriden (it happens in other places, like hr contract).

1. Now, it has been added a hook for setting it null when changing the state
2. Added in Form View 
   <img width="1116" height="340" alt="image" src="https://github.com/user-attachments/assets/73070cd6-918e-46c0-a5e2-51bef8fbefe6" />
3. Added in Tree View 
   <img width="767" height="382" alt="image" src="https://github.com/user-attachments/assets/3a9de68f-313a-4099-bcc5-c14c4135d078" />
4. Added filters for kanban state


