### PR TITLE
[18.0] [IMP] helpdesk_mgmt: categories visibility in portal

### DIFF
--- a/helpdesk_mgmt/controllers/main.py
+++ b/helpdesk_mgmt/controllers/main.py
@@ -46,7 +46,7 @@ class HelpdeskTicketController(http.Controller):
         company = request.env.company
         category_model = http.request.env["helpdesk.ticket.category"]
         categories = category_model.with_company(company.id).search(
-            [("active", "=", True)]
+            [("active", "=", True), ("show_in_portal", "=", True)]
         )
         email = http.request.env.user.email
         name = http.request.env.user.name

--- a/helpdesk_mgmt/models/helpdesk_ticket_category.py
+++ b/helpdesk_mgmt/models/helpdesk_ticket_category.py
@@ -36,6 +36,7 @@ class HelpdeskCategory(models.Model):
     complete_name = fields.Char(
         compute="_compute_complete_name", store=True, recursive=True
     )
+    show_in_portal = fields.Boolean(default=True)
 
     @api.depends("name", "parent_id.complete_name")
     def _compute_complete_name(self):

--- a/helpdesk_mgmt/views/helpdesk_ticket_category_views.xml
+++ b/helpdesk_mgmt/views/helpdesk_ticket_category_views.xml
@@ -11,6 +11,12 @@
                     domain="[('active','=',False)]"
                 />
                 <separator />
+                <filter
+                    string="Displayed in portal"
+                    name="show_in_portal"
+                    domain="[('show_in_portal','=',True)]"
+                />
+                <separator />
                 <field name="name" filter_domain="[('name', 'ilike', self)]" />
                 <field name="parent_id" />
                 <field name="company_id" groups="base.group_multi_company" />
@@ -53,6 +59,7 @@
                     <group name="main">
                         <field name="parent_id" />
                         <field name="child_id" widget="many2many_tags" readonly="1" />
+                        <field name="show_in_portal" widget="boolean_toggle" />
                         <field name="company_id" groups="base.group_multi_company" />
                         <field name="active" invisible="1" />
                     </group>
@@ -68,6 +75,7 @@
                 <field name="sequence" widget="handle" />
                 <field name="name" />
                 <field name="parent_id" />
+                <field name="show_in_portal" widget="boolean_toggle" />
                 <field
                     name="company_id"
                     optional="hide"


### PR DESCRIPTION
[fw-port it to 18] This IMP introduce a category filter to control which one are displayed in helpdesk portal.
17.0 PR  - https://github.com/OCA/helpdesk/pull/807

