### PR TITLE
[18.0] [IMP] helpdesk_product: ticket_active field location

### DIFF
--- a/helpdesk_product/views/product_view.xml
+++ b/helpdesk_product/views/product_view.xml
@@ -6,9 +6,12 @@
         <field name="model">product.template</field>
         <field name="inherit_id" ref="product.product_template_form_view" />
         <field name="arch" type="xml">
-            <field name="product_tooltip" position="before">
-                <field name="ticket_active" />
-            </field>
+            <div name="options" position='inside'>
+                <span class="d-inline-flex" invisible="type == 'combo'">
+                    <field name="ticket_active" />
+                    <label for="ticket_active" string="Helpdesk" />
+                </span>
+            </div>
         </field>
     </record>
 


### PR DESCRIPTION
Move the `ticket_active` field to a better location, just below the name -- just like with the other apps in core

Before:
<img width="615" height="445" alt="Screenshot 2025-09-10 at 4 25 07 PM" src="https://github.com/user-attachments/assets/e807d7f2-d7a6-4718-bfa6-e28b5dfcb200" />


After:
<img width="623" height="437" alt="Screenshot 2025-09-10 at 4 26 05 PM" src="https://github.com/user-attachments/assets/78b85a26-4142-4b3b-b638-577d6331fde2" />
