### PR TITLE
[18.0][IMP] helpdesk_mgmt_project: Show tickets on dashboard project view

### DIFF
--- a/helpdesk_mgmt_project/models/project.py
+++ b/helpdesk_mgmt_project/models/project.py
@@ -36,3 +36,30 @@ class ProjectProject(models.Model):
         for record in self:
             record.ticket_count = counts.get(record.id, 0)
             record.todo_ticket_count = counts_todo.get(record.id, 0)
+
+    def _get_stat_buttons(self):
+        buttons = super()._get_stat_buttons()
+        if self.env.user.has_group("helpdesk_mgmt.group_helpdesk_user_own"):
+            buttons.append(
+                {
+                    "icon": "life-ring",
+                    "text": self.env._("Tickets"),
+                    "number": self.ticket_count,
+                    "action_type": "object",
+                    "action": "action_open_helpdesk_tickets",
+                    "show": self.ticket_count > 0,
+                    "sequence": 4,
+                }
+            )
+        return buttons
+
+    def action_open_helpdesk_tickets(self):
+        self.ensure_one()
+        action = self.env["ir.actions.actions"]._for_xml_id(
+            "helpdesk_mgmt_project.ticket_action_from_project"
+        )
+        action["domain"] = [("project_id", "=", self.id)]
+        action["context"] = {
+            "default_project_id": self.id,
+        }
+        return action

--- a/helpdesk_mgmt_project/tests/test_helpdesk_ticket.py
+++ b/helpdesk_mgmt_project/tests/test_helpdesk_ticket.py
@@ -104,3 +104,27 @@ class TestHelpdeskTicketProject(TestHelpdeskTicketBase):
         self.ticket.write({"task_id": single_ticket_task.id})
         action = single_ticket_task.action_view_ticket()
         self.assertEqual(action["res_id"], self.ticket.id)
+
+    def test_project_update_buttons(self):
+        """Test that the project update button is only visible to users with the
+        'Project / Project Manager' group.
+        """
+        user = self._create_new_internal_user(groups="project.group_project_user")
+
+        buttons = self.project1.with_user(user)._get_stat_buttons()
+        self.assertFalse(
+            any(
+                button["action"] == "action_open_helpdesk_tickets" for button in buttons
+            )
+        )
+        buttons = self.project1._get_stat_buttons()
+        self.assertTrue(
+            any(
+                button["action"] == "action_open_helpdesk_tickets" for button in buttons
+            )
+        )
+        action = self.project1.action_open_helpdesk_tickets()
+        tickets = self.env[action["res_model"]].search(action["domain"])
+        self.assertEqual(len(tickets), 2)
+        self.assertIn(self.ticket, tickets)
+        self.assertIn(self.ticket2, tickets)

--- a/helpdesk_mgmt_project/views/project_task_view.xml
+++ b/helpdesk_mgmt_project/views/project_task_view.xml
@@ -8,7 +8,7 @@
                 <button
                     class="oe_stat_button"
                     type="action"
-                    icon="fa-file"
+                    icon="fa-life-ring"
                     name="%(ticket_action_from_project)d"
                     context="{'search_default_task_id': id, 'default_task_id': id, 'search_default_project_id': project_id, 'default_project_id': project_id}"
                     groups="helpdesk_mgmt.group_helpdesk_user_own"

--- a/helpdesk_mgmt_project/views/project_view.xml
+++ b/helpdesk_mgmt_project/views/project_view.xml
@@ -8,7 +8,7 @@
                 <button
                     class="oe_stat_button"
                     type="action"
-                    icon="fa-file"
+                    icon="fa-life-ring"
                     name="%(ticket_action_from_project)d"
                     context="{'search_default_project_id': id, 'default_project_id': id}"
                     groups="helpdesk_mgmt.group_helpdesk_user_own"


### PR DESCRIPTION
- Addsa the tickets on the project update view
- Change icon of tasks to life-ring

<img width="1494" height="377" alt="image" src="https://github.com/user-attachments/assets/702ed06e-9f40-4257-8f51-afb133a52006" />

<img width="1246" height="188" alt="image" src="https://github.com/user-attachments/assets/ce086753-3d21-4854-b57b-7ebdf9a18618" />

