### PR TITLE
[17.0] [IMP] helpdesk_mgmt: add category to list and tree views

### DIFF
--- a/helpdesk_mgmt/views/helpdesk_ticket_views.xml
+++ b/helpdesk_mgmt/views/helpdesk_ticket_views.xml
@@ -27,6 +27,7 @@
                 <field name="partner_email" />
                 <field name="user_id" />
                 <field name="name" />
+                <field name="category_id" />
                 <field name="tag_ids" />
                 <field name="stage_id" />
                 <filter
@@ -121,6 +122,12 @@
                         name="group_stage"
                         domain="[]"
                         context="{'group_by':'stage_id'}"
+                    />
+                    <filter
+                        string="Category"
+                        name="group_category"
+                        domain="[]"
+                        context="{'group_by':'category_id'}"
                     />
                     <filter
                         string="Tag"
@@ -236,6 +243,7 @@
                 <field name="partner_id" optional="hide" widget="many2one_avatar" />
                 <field name="partner_name" optional="show" />
                 <field name="user_id" optional="show" widget="many2one_avatar_user" />
+                <field name="category_id" optional="hide" />
                 <field name="unattended" column_invisible="1" />
                 <field name="closed" column_invisible="1" />
                 <field


### PR DESCRIPTION
This IMP adds the category field to the tree and search view.

- In the tree view, the category column can be shown or hidden as needed (default show).
- In the search view, users can search and group tickets by category.

<img width="1914" height="437" alt="image" src="https://github.com/user-attachments/assets/e79c778a-c021-450b-a48a-491f1ccafac9" />
<img width="1313" height="416" alt="image" src="https://github.com/user-attachments/assets/a4b07c0b-097c-489d-9fda-81993d2e8c04" />
<img width="1419" height="469" alt="image" src="https://github.com/user-attachments/assets/363ca347-7d4c-417b-9d48-286dd003de49" />
