### PR TITLE
[18.0][IMP] helpdesk_mgmt_sale: helpdesk.ticket.link.sale.order.wizard

### DIFF
--- a/helpdesk_mgmt_sale/README.rst
+++ b/helpdesk_mgmt_sale/README.rst
@@ -44,8 +44,13 @@ Usage
 To associate orders to Helpdesk tickets:
 
 1. Create or modify a Helpdesk ticket.
-2. In the ticket view, you will find a **Sales Order** Smartbutton which
-   will show the number of orders associated to the ticket.
+2. In the ticket view, you will find
+
+   -  a **Sales Order** Smartbutton which will show the number of orders
+      associated to the ticket.
+   -  a **Link Sale Orders** button to link existing orders to the
+      ticket.
+
 3. Clicking on the Smartbutton will open a view with all the sales
    orders related to the current ticket.
 4. To create an order associated to the ticket click on the **Create**
@@ -72,13 +77,17 @@ Authors
 Contributors
 ------------
 
-- `Tecnativa <https://www.tecnativa.com>`__:
+-  `Tecnativa <https://www.tecnativa.com>`__:
 
-  - Pilar Vargas
+   -  Pilar Vargas
 
-- `Heliconia Solutions Pvt. Ltd. <https://www.heliconia.io>`__
+-  `Heliconia Solutions Pvt. Ltd. <https://www.heliconia.io>`__
 
-  - Bhavesh Heliconia
+   -  Bhavesh Heliconia
+
+-  `Camptocamp <https://www.camptocamp.com>`__:
+
+   -  Vincent Van Rossem
 
 Maintainers
 -----------

--- a/helpdesk_mgmt_sale/__init__.py
+++ b/helpdesk_mgmt_sale/__init__.py
@@ -1,1 +1,2 @@
 from . import models
+from . import wizards

--- a/helpdesk_mgmt_sale/__manifest__.py
+++ b/helpdesk_mgmt_sale/__manifest__.py
@@ -10,8 +10,10 @@
     "website": "https://github.com/OCA/helpdesk",
     "depends": ["helpdesk_mgmt", "sale"],
     "data": [
+        "security/ir.model.access.csv",
         "views/helpdesk_ticket_views.xml",
         "views/sale_order_views.xml",
+        "wizards/helpdesk_ticket_link_sale_order.xml",
     ],
     "development_status": "Production/Stable",
     "auto_install": True,

--- a/helpdesk_mgmt_sale/models/helpdesk_ticket.py
+++ b/helpdesk_mgmt_sale/models/helpdesk_ticket.py
@@ -23,3 +23,24 @@ class HelpdeskTicket(models.Model):
             "default_partner_id": self.partner_id.id,
         }
         return action
+
+    def action_open_link_sale_order(self):
+        self.ensure_one()
+        commercial_partner = self.partner_id.commercial_partner_id
+        sale_orders = self.env["sale.order"].search(
+            [
+                ("partner_id.commercial_partner_id", "=", commercial_partner.id),
+                ("ticket_ids", "=", False),
+            ]
+        )
+        return {
+            "type": "ir.actions.act_window",
+            "res_model": "helpdesk.ticket.link.sale.order.wizard",
+            "view_mode": "form",
+            "target": "new",
+            "context": {
+                "default_ticket_id": self.id,
+                "default_commercial_partner_id": commercial_partner.id,
+                "default_sale_orders_ids": sale_orders.ids,
+            },
+        }

--- a/helpdesk_mgmt_sale/readme/CONTRIBUTORS.md
+++ b/helpdesk_mgmt_sale/readme/CONTRIBUTORS.md
@@ -2,3 +2,5 @@
   - Pilar Vargas
 - [Heliconia Solutions Pvt. Ltd.](https://www.heliconia.io)
   - Bhavesh Heliconia
+- [Camptocamp](https://www.camptocamp.com):
+  - Vincent Van Rossem

--- a/helpdesk_mgmt_sale/readme/USAGE.md
+++ b/helpdesk_mgmt_sale/readme/USAGE.md
@@ -1,8 +1,9 @@
 To associate orders to Helpdesk tickets:
 
 1.  Create or modify a Helpdesk ticket.
-2.  In the ticket view, you will find a **Sales Order** Smartbutton
-    which will show the number of orders associated to the ticket.
+2.  In the ticket view, you will find
+    * a **Sales Order** Smartbutton which will show the number of orders associated to the ticket.
+    * a **Link Sale Orders** button to link existing orders to the ticket.
 3.  Clicking on the Smartbutton will open a view with all the sales
     orders related to the current ticket.
 4.  To create an order associated to the ticket click on the **Create**

--- a/helpdesk_mgmt_sale/security/ir.model.access.csv
+++ b/helpdesk_mgmt_sale/security/ir.model.access.csv
@@ -1,0 +1,3 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_helpdesk_ticket_link_sale_order_wizard_manager,helpdesk.ticket.link.sale.order.wizard.manager,model_helpdesk_ticket_link_sale_order_wizard,helpdesk_mgmt.group_helpdesk_manager,1,1,1,0
+access_helpdesk_ticket_link_sale_order_wizard_user,helpdesk.ticket.link.sale.order.wizard.user,model_helpdesk_ticket_link_sale_order_wizard,helpdesk_mgmt.group_helpdesk_user,1,1,1,1

--- a/helpdesk_mgmt_sale/static/description/index.html
+++ b/helpdesk_mgmt_sale/static/description/index.html
@@ -392,8 +392,13 @@ ticket associated with it, allowing tickets and sales to be related.</p>
 <p>To associate orders to Helpdesk tickets:</p>
 <ol class="arabic simple">
 <li>Create or modify a Helpdesk ticket.</li>
-<li>In the ticket view, you will find a <strong>Sales Order</strong> Smartbutton which
-will show the number of orders associated to the ticket.</li>
+<li>In the ticket view, you will find<ul>
+<li>a <strong>Sales Order</strong> Smartbutton which will show the number of orders
+associated to the ticket.</li>
+<li>a <strong>Link Sale Orders</strong> button to link existing orders to the
+ticket.</li>
+</ul>
+</li>
 <li>Clicking on the Smartbutton will open a view with all the sales
 orders related to the current ticket.</li>
 <li>To create an order associated to the ticket click on the <strong>Create</strong>
@@ -425,6 +430,10 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 </li>
 <li><a class="reference external" href="https://www.heliconia.io">Heliconia Solutions Pvt. Ltd.</a><ul>
 <li>Bhavesh Heliconia</li>
+</ul>
+</li>
+<li><a class="reference external" href="https://www.camptocamp.com">Camptocamp</a>:<ul>
+<li>Vincent Van Rossem</li>
 </ul>
 </li>
 </ul>

--- a/helpdesk_mgmt_sale/tests/test_helpdesk_ticket.py
+++ b/helpdesk_mgmt_sale/tests/test_helpdesk_ticket.py
@@ -55,3 +55,46 @@ class TestHelpdeskTicketSale(BaseCommon):
         self.assertEqual(
             action["context"]["default_ticket_ids"], [Command.link([self.ticket.id])]
         )
+
+    def test_helpdesk_ticket_link_sale_order_wizard(self):
+        action = self.ticket.action_open_link_sale_order()
+        context = action["context"]
+        self.assertEqual(context["default_ticket_id"], self.ticket.id)
+        self.assertEqual(
+            context["default_commercial_partner_id"],
+            self.partner.commercial_partner_id.id,
+        )
+
+        wizard = (
+            self.env["helpdesk.ticket.link.sale.order.wizard"]
+            .with_context(**context)
+            .create({})
+        )
+
+        # Pre-existing sale orders are already linked to the ticket
+        self.assertEqual(len(wizard.sale_orders_ids), 0)
+
+        # Create a new sale order not linked to any ticket
+        sale_order = self.env["sale.order"].create({"partner_id": self.partner.id})
+
+        # Reopen the wizard to refresh available sale orders
+        action = self.ticket.action_open_link_sale_order()
+        context = action["context"]
+        self.assertEqual(len(context["default_sale_orders_ids"]), 1)
+        self.assertIn(sale_order.id, context["default_sale_orders_ids"])
+        wizard = (
+            self.env["helpdesk.ticket.link.sale.order.wizard"]
+            .with_context(**context)
+            .create({})
+        )
+
+        # Verify the wizard now lists the newly created sale order
+        self.assertEqual(len(wizard.sale_orders_ids), 1)
+        self.assertIn(sale_order, wizard.sale_orders_ids)
+
+        # Confirm linking the selected sale order to the ticket
+        wizard.action_confirm()
+
+        # Check that the ticket's sale_order_ids now includes the new sale order
+        self.assertIn(sale_order, self.ticket.sale_order_ids)
+        self.assertEqual(self.ticket.so_count, 3)

--- a/helpdesk_mgmt_sale/views/helpdesk_ticket_views.xml
+++ b/helpdesk_mgmt_sale/views/helpdesk_ticket_views.xml
@@ -6,6 +6,14 @@
         <field name="model">helpdesk.ticket</field>
         <field name="inherit_id" ref="helpdesk_mgmt.ticket_view_form" />
         <field name="arch" type="xml">
+            <header position="inside">
+                <button
+                    name="action_open_link_sale_order"
+                    type="object"
+                    string="Link Sale Orders"
+                    class="btn-secondary"
+                />
+            </header>
             <xpath expr="//div[@name='button_box']" position="inside">
                 <button
                     name="action_view_sale_orders"

--- a/helpdesk_mgmt_sale/wizards/__init__.py
+++ b/helpdesk_mgmt_sale/wizards/__init__.py
@@ -1,0 +1,1 @@
+from . import helpdesk_ticket_link_sale_order

--- a/helpdesk_mgmt_sale/wizards/helpdesk_ticket_link_sale_order.py
+++ b/helpdesk_mgmt_sale/wizards/helpdesk_ticket_link_sale_order.py
@@ -1,0 +1,27 @@
+from odoo import Command, fields, models
+
+
+class HelpdeskTicketLinkSaleOrderWizard(models.TransientModel):
+    _name = "helpdesk.ticket.link.sale.order.wizard"
+    _description = "Link Sale Orders to Helpdesk Ticket"
+
+    ticket_id = fields.Many2one("helpdesk.ticket", required=True, readonly=True)
+    ticket_sale_order_ids = fields.Many2many(
+        "sale.order", related="ticket_id.sale_order_ids", readonly=True
+    )
+    commercial_partner_id = fields.Many2one("res.partner", readonly=True)
+    sale_orders_ids = fields.Many2many(
+        "sale.order",
+        domain="["
+        "   ('partner_id.commercial_partner_id', '=', commercial_partner_id),"
+        "   ('id', 'not in', ticket_sale_order_ids)"
+        "]",
+        required=True,
+    )
+
+    def action_confirm(self):
+        self.ensure_one()
+        if self.sale_orders_ids:
+            self.ticket_id.sale_order_ids = [
+                Command.link(so.id) for so in self.sale_orders_ids
+            ]

--- a/helpdesk_mgmt_sale/wizards/helpdesk_ticket_link_sale_order.xml
+++ b/helpdesk_mgmt_sale/wizards/helpdesk_ticket_link_sale_order.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="view_helpdesk_ticket_link_sale_order_wizard" model="ir.ui.view">
+        <field name="name">helpdesk.ticket.link.sale.order.wizard.form</field>
+        <field name="model">helpdesk.ticket.link.sale.order.wizard</field>
+        <field name="arch" type="xml">
+            <form string="Link Sale Orders">
+                <field name="sale_orders_ids" />
+                <footer>
+                    <button
+                        name="action_confirm"
+                        type="object"
+                        string="Link Sale Orders"
+                        class="btn-primary"
+                    />
+                    <button string="Cancel" special="cancel" />
+                </footer>
+            </form>
+        </field>
+    </record>
+
+    <record
+        id="action_helpdesk_ticket_link_sale_order_wizard"
+        model="ir.actions.act_window"
+    >
+        <field name="name">Link Sale Orders</field>
+        <field name="res_model">helpdesk.ticket.link.sale.order.wizard</field>
+        <field name="view_mode">form</field>
+        <field name="target">new</field>
+    </record>
+</odoo>


### PR DESCRIPTION
Clicking on "Link Sale Orders" opens the following wizard where the orders of the contact's _Commercial Entity_ are pre-selected.
The sale orders already associated to a ticket are not included.
<img width="1919" height="1050" alt="Screenshot from 2025-09-18 09-21-10" src="https://github.com/user-attachments/assets/fe9826d4-693f-473c-b744-d2bed20d2406" />
Removing some pre-selected sale orders and adding a line displays only the sale orders of the contact's Commercial Entity.
The sale orders already associated to this ticket are not included.
<img width="1919" height="1050" alt="Screenshot from 2025-09-18 09-21-37" src="https://github.com/user-attachments/assets/de2ba894-ad66-4b9e-acad-42c96753030f" />
