### PR TITLE
[18.0][IMP] helpdesk_mgmt_fieldservice: propagate ticket description

### DIFF
--- a/helpdesk_mgmt_fieldservice/models/helpdesk_ticket.py
+++ b/helpdesk_mgmt_fieldservice/models/helpdesk_ticket.py
@@ -4,6 +4,7 @@
 
 from odoo import api, fields, models
 from odoo.exceptions import ValidationError
+from odoo.tools import html2plaintext
 
 
 class HelpdeskTicket(models.Model):
@@ -66,6 +67,7 @@ class HelpdeskTicket(models.Model):
             "default_ticket_id": self.id,
             "default_priority": self.priority,
             "default_location_id": self.fsm_location_id.id,
+            "default_description": html2plaintext(self.description).strip(),
         }
         res = self.env.ref("fieldservice.fsm_order_form", False)
         action["views"] = [(res and res.id or False, "form")]

--- a/helpdesk_mgmt_fieldservice/tests/test_helpdesk_ticket_fsm_order.py
+++ b/helpdesk_mgmt_fieldservice/tests/test_helpdesk_ticket_fsm_order.py
@@ -3,6 +3,7 @@
 
 from odoo.exceptions import ValidationError
 from odoo.tests import Form, TransactionCase
+from odoo.tools import html2plaintext
 
 from odoo.addons.base.tests.common import DISABLED_MAIL_CONTEXT
 
@@ -86,6 +87,7 @@ class TestHelpdeskTicketFSMOrder(TransactionCase):
                     "ticket_id": self.ticket_1.id,
                     "priority": self.ticket_1.priority,
                     "location_id": self.test_location.id,
+                    "description": html2plaintext(self.ticket_1.description).strip(),
                 }
                 for _ in range(5)
             ],


### PR DESCRIPTION
Propagates `helpdesk.ticket.description` when creating the FSM Order (via `helpdesk.ticket::action_create_order()`)