### PR TITLE
[18.0][FIX] helpdesk_mgmt_project: migrate's signature

### DIFF
--- a/helpdesk_mgmt_project/migrations/18.0.1.1.0/pre-migration.py
+++ b/helpdesk_mgmt_project/migrations/18.0.1.1.0/pre-migration.py
@@ -1,8 +1,11 @@
 from openupgradelib import openupgrade
 
+from odoo import SUPERUSER_ID, api
 
-@openupgrade.migrate()
-def migrate(env, version):
+
+def migrate(cr, version):
+    env = api.Environment(cr, SUPERUSER_ID, {})
+
     if not openupgrade.column_exists(env.cr, "helpdesk_ticket", "milestone_id"):
         openupgrade.add_fields(
             env,


### PR DESCRIPTION
Fixes `TypeError: module helpdesk_mgmt_project: migrate's signature should be (cr, version)`