### PR TITLE
[18.0][IMP] helpdesk_mgmt: Improve user and team assignment in helpdesk tickets

### DIFF
--- a/helpdesk_mgmt/models/helpdesk_ticket.py
+++ b/helpdesk_mgmt/models/helpdesk_ticket.py
@@ -25,8 +25,18 @@ class HelpdeskTicket(models.Model):
     @api.depends("team_id")
     def _compute_user_id(self):
         for ticket in self:
-            if not ticket.user_id and ticket.team_id:
-                ticket.user_id = ticket.team_id.create_uid
+            if not ticket.user_id:
+                ticket.user_id = self.env.user
+            if ticket.team_id and ticket.user_id not in ticket.team_id.user_ids:
+                # If the user is not part of the team, we remove the user
+                ticket.user_id = False
+
+    @api.depends("user_id")
+    def _compute_team_id(self):
+        for ticket in self:
+            if not ticket.team_id and ticket.user_id.helpdesk_team_ids:
+                # If no team is set, we default to the user's first team
+                ticket.team_id = ticket.user_id.helpdesk_team_ids[0]
 
     @api.model
     def _read_group_stage_ids(self, stages, domain):
@@ -52,6 +62,9 @@ class HelpdeskTicket(models.Model):
         string="Assigned user",
         tracking=True,
         index=True,
+        compute="_compute_user_id",
+        store=True,
+        readonly=False,
         domain="team_id and [('share', '=', False),('id', 'in', user_ids)] or [('share', '=', False)]",  # noqa: B950,E501
     )
     user_ids = fields.Many2many(
@@ -104,6 +117,9 @@ class HelpdeskTicket(models.Model):
         comodel_name="helpdesk.ticket.team",
         string="Team",
         index=True,
+        compute="_compute_team_id",
+        store=True,
+        readonly=False,
     )
     priority = fields.Selection(
         selection=[

--- a/helpdesk_mgmt/tests/test_helpdesk_ticket.py
+++ b/helpdesk_mgmt/tests/test_helpdesk_ticket.py
@@ -1,5 +1,7 @@
 import time
 
+from odoo.tests import Form
+
 from .common import TestHelpdeskTicketBase
 
 
@@ -181,3 +183,32 @@ class TestHelpdeskTicket(TestHelpdeskTicketBase):
             }
         )
         self.assertEqual(self.new_stage, new_ticket.stage_id)
+
+    def test_ticket_default_user_team(self):
+        """The ticket should take the current user
+        and the first team assigned to that user
+        """
+        new_ticket = (
+            self.env["helpdesk.ticket"]
+            .with_user(self.user_own)
+            .create(
+                {
+                    "name": "New Ticket",
+                    "description": "Description",
+                }
+            )
+        )
+        self.assertEqual(new_ticket.user_id, self.user_own)
+        self.assertEqual(new_ticket.team_id, self.team_a)
+        # Change the user to another one with the same team
+        # the team should remain unchanged
+        new_ticket.user_id = self.user
+        self.assertEqual(new_ticket.team_id, self.team_a)
+        new_team = self.env["helpdesk.ticket.team"].create({"name": "New Team"})
+        # Change the team to another one where the user is not assigned.
+        # The user should be removed from the ticket.
+        # Use sudo to avoid access rights issues,
+        # because the user only belongs to the group `group_helpdesk_user_own`.
+        with Form(new_ticket.sudo()) as new_ticket_form:
+            new_ticket_form.team_id = new_team
+            self.assertFalse(new_ticket_form.user_id)

--- a/helpdesk_mgmt_merge/tests/test_helpdesk_mgmt_merge.py
+++ b/helpdesk_mgmt_merge/tests/test_helpdesk_mgmt_merge.py
@@ -28,7 +28,7 @@ class TestHelpdeskTicketMerge(BaseCommon):
         self.ticket_merge_2 = self.HelpdeskTicketMerge.with_context(
             active_ids=[self.ticket_1.id, self.ticket_2.id]
         ).create({})
-        self.assertFalse(self.ticket_merge_2.user_id)
+        self.assertEqual(self.ticket_merge_2.user_id, self.env.user)
         self.ticket_2.user_id = self.env.user.id
         self.ticket_merge_2.dst_ticket_id = self.ticket_2.id
         self.ticket_merge_2._onchange_dst_ticket_id()


### PR DESCRIPTION
- Assign the current user by default if no user is set.
- Assign the first team of the user.
- When the team is changed, if the user is not in the team, unset the user.

Forward-port of https://github.com/OCA/helpdesk/pull/776

@Tecnativa @pedrobaeza @victoralmau could you please review this?