### PR TITLE
[17.0] [FIX] helpdesk_ticket_close_inactive: correct relation definition of ticket_stage_ids field on helpdesk team

### DIFF
--- a/helpdesk_ticket_close_inactive/models/helpdesk_ticket_team.py
+++ b/helpdesk_ticket_close_inactive/models/helpdesk_ticket_team.py
@@ -31,6 +31,7 @@ class HelpdeskTicketTeam(models.Model):
     )
     ticket_stage_ids = fields.Many2many(
         comodel_name="helpdesk.ticket.stage",
+        relation="helpdesk_team_stage_closing_ticket_filter_rel",
         string="Ticket Stage",
         help="The cronjob will check for inactivity in \
         tickets that are in these stages.",


### PR DESCRIPTION
Fixes #839.

Basically, `ticket_stage_ids` is not the only **many2many** field linking to stages from the **helpdesk.ticket.team** model. As a result, the ORM was getting confused — a single relational table was being used for multiple fields. So, when one was set, **all were being set**.

@BinhexTeam