### PR TITLE
[18.0] [IMP] helpdesk_mgmt: improve portal form settings page

### DIFF
--- a/helpdesk_mgmt/views/res_config_settings_views.xml
+++ b/helpdesk_mgmt/views/res_config_settings_views.xml
@@ -11,24 +11,61 @@
                     name="helpdesk_mgmt"
                     groups="helpdesk_mgmt.group_helpdesk_manager"
                 >
-                    <block title="New ticket form (portal)">
-                        <setting help="Show teams form">
-                            <field name="helpdesk_mgmt_portal_select_team" />
+                    <block
+                        title="New ticket form (portal)"
+                        name="helpdesk_mgmt_portal_new_ticket_fields"
+                    >
+                        <setting
+                            id="helpdesk_mgmt_portal_new_ticket_fields"
+                            company_dependent="1"
+                            string="Additional fields"
+                            help="Whether to display additional fields in the portal form"
+                        >
+                            <div
+                                class="content-group"
+                                name="helpdesk_mgmt_portal_new_ticket_fields"
+                            >
+                                <div class="mt8">
+                                    <field name="helpdesk_mgmt_portal_select_team" />
+                                    <label
+                                        for="helpdesk_mgmt_portal_select_team"
+                                        string="Team"
+                                    />
+                                </div>
+                            </div>
                         </setting>
-                        <setting>
-                            <field
-                                name="helpdesk_mgmt_portal_team_id_required"
-                                readonly="not helpdesk_mgmt_portal_select_team"
-                                string="Required Team"
-                            />
-                        </setting>
-                    </block>
-                    <block>
-                        <setting>
-                            <field
-                                name="helpdesk_mgmt_portal_category_id_required"
-                                string="Required Category"
-                            />
+                        <setting
+                            id="helpdesk_mgmt_portal_new_ticket_required_fields"
+                            company_dependent="1"
+                            string="Required fields"
+                            help="Choose which fields are required in the portal form"
+                        >
+                            <div
+                                class="content-group"
+                                name="helpdesk_mgmt_portal_new_ticket_required_fields"
+                            >
+                                <div class="mt8">
+                                    <field
+                                        name="helpdesk_mgmt_portal_category_id_required"
+                                    />
+                                    <label
+                                        for="helpdesk_mgmt_portal_category_id_required"
+                                        string="Category"
+                                    />
+                                </div>
+                                <div
+                                    class="mt8"
+                                    invisible="not helpdesk_mgmt_portal_select_team"
+                                >
+                                    <field
+                                        name="helpdesk_mgmt_portal_team_id_required"
+                                    />
+                                    <label
+                                        for="helpdesk_mgmt_portal_team_id_required"
+                                        string="Team"
+                                    />
+                                </div>
+                            </div>
                         </setting>
                     </block>
                 </app>

--- a/helpdesk_type/views/res_config_settings_views.xml
+++ b/helpdesk_type/views/res_config_settings_views.xml
@@ -6,33 +6,22 @@
         <field name="inherit_id" ref="helpdesk_mgmt.res_config_settings_view_form" />
         <field name="arch" type="xml">
             <xpath
-                expr="//setting[field[@name='helpdesk_mgmt_portal_select_team']]"
-                position="after"
+                expr="//app[@name='helpdesk_mgmt']//div[@name='helpdesk_mgmt_portal_new_ticket_fields']"
+                position="inside"
             >
-                <setting
-                    string="Types"
-                    id="show_type_form"
-                    help="Controls if the types are visible on the portal and if they are required."
-                >
-                    <div class="mt16">
-                        <div class="content-group">
-                            <div>
-                                <field
-                                    name="helpdesk_mgmt_portal_type"
-                                    string="Display"
-                                />
-                                <label for="helpdesk_mgmt_portal_type" />
-                            </div>
-                            <div invisible="not helpdesk_mgmt_portal_type">
-                                <field
-                                    name="helpdesk_mgmt_portal_type_id_required"
-                                    string="Required"
-                                />
-                                <label for="helpdesk_mgmt_portal_type_id_required" />
-                            </div>
-                        </div>
-                    </div>
-                </setting>
+                <div class="mt8">
+                    <field name="helpdesk_mgmt_portal_type" />
+                    <label for="helpdesk_mgmt_portal_type" string="Type" />
+                </div>
+            </xpath>
+            <xpath
+                expr="//app[@name='helpdesk_mgmt']//div[@name='helpdesk_mgmt_portal_new_ticket_required_fields']"
+                position="inside"
+            >
+                <div class="mt8" invisible="not helpdesk_mgmt_portal_type">
+                    <field name="helpdesk_mgmt_portal_type_id_required" />
+                    <label for="helpdesk_mgmt_portal_type_id_required" string="Type" />
+                </div>
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
Organize the Settings page

Before:
<img width="2558" height="1314" alt="image" src="https://github.com/user-attachments/assets/c116b855-63e5-468f-a5bb-e3fa81e5c981" />

After:
<img width="2502" height="1234" alt="image" src="https://github.com/user-attachments/assets/4f7998d5-8879-4c5f-9150-908c382d1e2e" />
