### PR TITLE
[16.0][REF] helpdesk_portal_restriction: call super().create_new_ticket() and override only categories in qcontex

### DIFF
--- a/helpdesk_portal_restriction/controllers/main.py
+++ b/helpdesk_portal_restriction/controllers/main.py
@@ -1,7 +1,6 @@
 import logging
 
 import odoo.http as http
-from odoo.http import request
 
 from odoo.addons.helpdesk_mgmt.controllers.main import HelpdeskTicketController
 
@@ -32,23 +31,7 @@ class HelpdeskPartnerTeamCategoryController(HelpdeskTicketController):
 
     @http.route("/new/ticket", type="http", auth="user", website=True)
     def create_new_ticket(self, **kw):
-        session_info = http.request.env["ir.http"].session_info()
-        email = http.request.env.user.email
-        name = http.request.env.user.name
-        company = request.env.company
-        return http.request.render(
-            "helpdesk_mgmt.portal_create_ticket",
-            {
-                "categories": self._get_category(),
-                "teams": self._get_teams(),
-                "email": email,
-                "name": name,
-                "ticket_team_id_required": (
-                    company.helpdesk_mgmt_portal_team_id_required
-                ),
-                "ticket_category_id_required": (
-                    company.helpdesk_mgmt_portal_category_id_required
-                ),
-                "max_upload_size": session_info["max_file_upload_size"],
-            },
-        )
+        res = super().create_new_ticket(**kw)
+        res.qcontext["categories"] = self._get_category()
+
+        return res


### PR DESCRIPTION
This pull request refactors the `create_new_ticket` method in the `helpdesk_portal_restriction/controllers/main.py` file to simplify its logic and delegate more responsibility to the parent class. The main change is to call the superclass implementation and then inject the custom categories into the response context, instead of manually constructing the entire context.

Refactoring and code simplification:

* Refactored the `create_new_ticket` method to call `super().create_new_ticket(**kw)` and then update the response context with custom categories, reducing code duplication and leveraging the parent class's logic.

Cleanup:

* Removed unused import of `request` from `odoo.http` to tidy up the imports.