### PR TITLE
[16.0][IMP] helpdesk_mgmt: separate filters to force AND logic

### DIFF
--- a/helpdesk_mgmt/views/helpdesk_ticket_views.xml
+++ b/helpdesk_mgmt/views/helpdesk_ticket_views.xml
@@ -33,12 +33,15 @@
                     name="unassigned"
                     domain="[('user_id','=',False)]"
                 />
+                <separator />
                 <filter string="Open" name="open" domain="[('closed', '=', False )]" />
+                <separator />
                 <filter
                     string="Unattended"
                     name="unattended"
                     domain="[('unattended', '=', True )]"
                 />
+                <separator />
                 <filter
                     string="High Priority"
                     name="high_priority"
@@ -73,6 +76,7 @@
                     name="activities_my"
                     domain="[('activity_ids.user_id', '=', uid)]"
                 />
+                <separator />
                 <filter
                     string="Late Activities"
                     name="activities_overdue"


### PR DESCRIPTION
When filters are not separated with another element, their domains are combined with an OR selection. This is almost certainly not what you want. If you select Open Tickets end My tickets, you expect your tickets that are also open, not a combination of open tickets and tickets assigned to you.