### PR TITLE
[17.0][FIX] helpdesk_mgmt: Do not self-define user in tickets

### DIFF
--- a/helpdesk_mgmt/models/res_company.py
+++ b/helpdesk_mgmt/models/res_company.py
@@ -18,3 +18,7 @@ class Company(models.Model):
         string="Required Category field in Helpdesk portal",
         default=True,
     )
+    helpdesk_mgmt_ticket_auto_assign = fields.Boolean(
+        string="Auto assign tickets",
+        default=True,
+    )

--- a/helpdesk_mgmt/models/res_config_settings.py
+++ b/helpdesk_mgmt/models/res_config_settings.py
@@ -18,3 +18,7 @@ class ResConfigSettings(models.TransientModel):
         related="company_id.helpdesk_mgmt_portal_category_id_required",
         readonly=False,
     )
+    helpdesk_mgmt_ticket_auto_assign = fields.Boolean(
+        related="company_id.helpdesk_mgmt_ticket_auto_assign",
+        readonly=False,
+    )

--- a/helpdesk_mgmt/tests/test_helpdesk_ticket.py
+++ b/helpdesk_mgmt/tests/test_helpdesk_ticket.py
@@ -213,6 +213,32 @@ class TestHelpdeskTicket(TestHelpdeskTicketBase):
             new_ticket_form.team_id = new_team
             self.assertFalse(new_ticket_form.user_id)
 
+    def test_ticket_auto_assign(self):
+        self.company.helpdesk_mgmt_ticket_auto_assign = True
+        ticket_a = (
+            self.env["helpdesk.ticket"]
+            .with_user(self.user_own)
+            .create(
+                {
+                    "name": "New Ticket A",
+                    "description": "Description",
+                }
+            )
+        )
+        self.assertEqual(ticket_a.user_id, self.user_own)
+        self.company.helpdesk_mgmt_ticket_auto_assign = False
+        ticket_b = (
+            self.env["helpdesk.ticket"]
+            .with_user(self.user_team)
+            .create(
+                {
+                    "name": "New Ticket B",
+                    "description": "Description",
+                }
+            )
+        )
+        self.assertFalse(ticket_b.user_id)
+
     def test_ticket_change_user_no_stage_reset(self):
         in_progress_stage = self.env.ref(
             "helpdesk_mgmt.helpdesk_ticket_stage_in_progress"

--- a/helpdesk_mgmt/views/res_config_settings_views.xml
+++ b/helpdesk_mgmt/views/res_config_settings_views.xml
@@ -60,6 +60,25 @@
                             </div>
                         </setting>
                     </block>
+                    <block title="Helpdesk">
+                        <setting
+                            string="Tickets"
+                            id="helpdesk_mgmt_ticket_misc"
+                            help="Controls if the tickets created are automatically assigned to the user."
+                        >
+                            <div class="mt16">
+                                <div class="content-group">
+                                    <div>
+                                        <field
+                                            name="helpdesk_mgmt_ticket_auto_assign"
+                                            string="Auto assign User"
+                                        />
+                                        <label for="helpdesk_mgmt_ticket_auto_assign" />
+                                    </div>
+                                </div>
+                            </div>
+                        </setting>
+                    </block>
                 </app>
             </xpath>
         </field>

--- a/helpdesk_mgmt_stage_validation/tests/test_helpdesk_ticket_stage_validation.py
+++ b/helpdesk_mgmt_stage_validation/tests/test_helpdesk_ticket_stage_validation.py
@@ -13,6 +13,7 @@ class TestHelpdeskStageValidation(TransactionCase):
     def setUpClass(cls):
         super().setUpClass()
         cls.env = cls.env["base"].with_context(**DISABLED_MAIL_CONTEXT).env
+        cls.env.company.helpdesk_mgmt_ticket_auto_assign = False
         cls.stage = cls.env["helpdesk.ticket.stage"]
         cls.helpdesk_ticket = cls.env["helpdesk.ticket"]
         cls.ir_model_fields = cls.env["ir.model.fields"]


### PR DESCRIPTION
Do not self-define user in tickets

Previously, when creating a ticket, the user who was creating it was defined as the user, even if no team was defined; now, that logic has been removed from `_compute_user_id()` and moved a configuration option that allows each
company to decide whether tickets are self-assigned or not.

It is important to clarify that this change is **NOT** added to https://github.com/OCA/helpdesk/pull/889 because, although they are similar, they are different, and this change will probably generate debate and take time to merge.

Please @pedrobaeza and @carlos-lopez-tecnativa can you review it?

@Tecnativa TT59493