### PR TITLE
[18.0][FIX] helpdesk_mgmt: Do not automatically assign a user when creating tickets from the portal

### DIFF
--- a/helpdesk_mgmt/controllers/main.py
+++ b/helpdesk_mgmt/controllers/main.py
@@ -84,6 +84,7 @@ class HelpdeskTicketController(http.Controller):
             "partner_id": request.env.user.partner_id.id,
             "partner_name": request.env.user.partner_id.name,
             "partner_email": request.env.user.partner_id.email,
+            "user_id": False,
         }
         team = http.request.env["helpdesk.ticket.team"]
         if company.helpdesk_mgmt_portal_select_team and kw.get("team"):

--- a/helpdesk_mgmt/tests/test_helpdesk_portal.py
+++ b/helpdesk_mgmt/tests/test_helpdesk_portal.py
@@ -75,8 +75,11 @@ class TestHelpdeskPortal(TestHelpdeskPortalBase):
 
     def test_submit_ticket_02(self):
         self.authenticate("portal", "portal")
+        old_tickets = self.get_new_tickets(self.user_portal)
         self._submit_ticket()
         tickets = self.get_new_tickets(self.user_portal)
+        new_ticket = tickets - old_tickets
+        self.assertFalse(new_ticket.user_id)
         self.assertIn(self.portal_ticket, tickets)
         self.assertIn(self.new_ticket_title, tickets.mapped("name"))
         self.assertIn(


### PR DESCRIPTION
FWP from 17.0: https://github.com/OCA/helpdesk/pull/889

Do not automatically assign a user when creating tickets from the portal

Previously, the portal user who created the ticket was defined as the ticket user (completely incorrect)

Please @pedrobaeza and @carlos-lopez-tecnativa can you review it?

@Tecnativa TT59493