### PR TITLE
[18.0][FIX] helpdesk_mgmt: Do not self-define user in tickets

### DIFF
--- a/helpdesk_mgmt/models/helpdesk_ticket.py
+++ b/helpdesk_mgmt/models/helpdesk_ticket.py
@@ -25,8 +25,6 @@ class HelpdeskTicket(models.Model):
     @api.depends("team_id")
     def _compute_user_id(self):
         for ticket in self:
-            if not ticket.user_id:
-                ticket.user_id = self.env.user
             if ticket.team_id and ticket.user_id not in ticket.team_id.user_ids:
                 # If the user is not part of the team, we remove the user
                 ticket.user_id = False
@@ -192,6 +190,26 @@ class HelpdeskTicket(models.Model):
             "target": "new",
             "domain": [("duplicate_id", "=", self.id)],
         }
+
+    @api.model
+    def default_get(self, fields):
+        # The appropriate user is defined only if the "Auto assign User" option is
+        # checked in the company.
+        # If the team is set, the user must belong to that team.
+        defaults = super().default_get(fields)
+        company_id = defaults.get("company_id") or self.env.company.id
+        if "user_id" in fields and not defaults.get("user_id"):
+            company = self.env["res.company"].browse(company_id)
+            if company.helpdesk_mgmt_ticket_auto_assign:
+                if defaults.get("team_id"):
+                    team = self.env["helpdesk.ticket.team"].browse(
+                        defaults.get("team_id")
+                    )
+                    if self.env.user in team.user_ids:
+                        defaults["user_id"] = self.env.user.id
+                else:
+                    defaults["user_id"] = self.env.user.id
+        return defaults
 
     @api.depends("name")
     def _compute_display_name(self):

--- a/helpdesk_mgmt/models/res_company.py
+++ b/helpdesk_mgmt/models/res_company.py
@@ -26,3 +26,7 @@ class Company(models.Model):
         string="Move duplicate tickets to this stage",
         default=False,
     )
+    helpdesk_mgmt_ticket_auto_assign = fields.Boolean(
+        string="Auto assign tickets",
+        default=True,
+    )

--- a/helpdesk_mgmt/models/res_config_settings.py
+++ b/helpdesk_mgmt/models/res_config_settings.py
@@ -24,3 +24,7 @@ class ResConfigSettings(models.TransientModel):
     helpdesk_mgmt_duplicate_ticket_stage_id = fields.Many2one(
         related="company_id.helpdesk_mgmt_duplicate_ticket_stage_id", readonly=False
     )
+    helpdesk_mgmt_ticket_auto_assign = fields.Boolean(
+        related="company_id.helpdesk_mgmt_ticket_auto_assign",
+        readonly=False,
+    )

--- a/helpdesk_mgmt/tests/test_helpdesk_ticket.py
+++ b/helpdesk_mgmt/tests/test_helpdesk_ticket.py
@@ -213,6 +213,32 @@ class TestHelpdeskTicket(TestHelpdeskTicketBase):
             new_ticket_form.team_id = new_team
             self.assertFalse(new_ticket_form.user_id)
 
+    def test_ticket_auto_assign(self):
+        self.company.helpdesk_mgmt_ticket_auto_assign = True
+        ticket_a = (
+            self.env["helpdesk.ticket"]
+            .with_user(self.user_own)
+            .create(
+                {
+                    "name": "New Ticket A",
+                    "description": "Description",
+                }
+            )
+        )
+        self.assertEqual(ticket_a.user_id, self.user_own)
+        self.company.helpdesk_mgmt_ticket_auto_assign = False
+        ticket_b = (
+            self.env["helpdesk.ticket"]
+            .with_user(self.user_team)
+            .create(
+                {
+                    "name": "New Ticket B",
+                    "description": "Description",
+                }
+            )
+        )
+        self.assertFalse(ticket_b.user_id)
+
     def test_helpdesk_ticket_duplicates(self):
         self.env.company.helpdesk_mgmt_duplicate_tracking = True
         self.env.company.helpdesk_mgmt_duplicate_ticket_stage_id = self.env.ref(

--- a/helpdesk_mgmt/views/res_config_settings_views.xml
+++ b/helpdesk_mgmt/views/res_config_settings_views.xml
@@ -85,6 +85,25 @@
                             />
                         </setting>
                     </block>
+                    <block title="Helpdesk">
+                        <setting
+                            string="Tickets"
+                            id="helpdesk_mgmt_ticket_misc"
+                            help="Controls if the tickets created are automatically assigned to the user."
+                        >
+                            <div class="mt16">
+                                <div class="content-group">
+                                    <div>
+                                        <field
+                                            name="helpdesk_mgmt_ticket_auto_assign"
+                                            string="Auto assign User"
+                                        />
+                                        <label for="helpdesk_mgmt_ticket_auto_assign" />
+                                    </div>
+                                </div>
+                            </div>
+                        </setting>
+                    </block>
                 </app>
             </xpath>
         </field>


### PR DESCRIPTION
FWP from 17.0: https://github.com/OCA/helpdesk/pull/890

Do not self-define user in tickets

Previously, when creating a ticket, the user who was creating it was defined as the user, even if no team was defined; now, that logic has been removed from `_compute_user_id()` and moved a configuration option that allows each
company to decide whether tickets are self-assigned or not.

It is important to clarify that this change is **NOT** added to https://github.com/OCA/helpdesk/pull/889 because, although they are similar, they are different, and this change will probably generate debate and take time to merge.

Please @pedrobaeza and @carlos-lopez-tecnativa can you review it?

@Tecnativa TT59493