### PR TITLE
[18.0] [FIX] `helpdesk_mgmt_fieldservice`: align to changes in `fieldservice` module

### DIFF
--- a/helpdesk_mgmt_fieldservice/models/helpdesk_ticket.py
+++ b/helpdesk_mgmt_fieldservice/models/helpdesk_ticket.py
@@ -18,7 +18,7 @@ class HelpdeskTicket(models.Model):
         store=True,
         readonly=False,
     )
-    resolution = fields.Text()
+    resolution = fields.Html()
 
     @api.constrains("stage_id")
     def _validate_stage_fields(self):

--- a/helpdesk_mgmt_fieldservice/tests/test_helpdesk_ticket_fsm_order.py
+++ b/helpdesk_mgmt_fieldservice/tests/test_helpdesk_ticket_fsm_order.py
@@ -143,7 +143,9 @@ class TestHelpdeskTicketFSMOrder(TransactionCase):
             wizard.stage_id = self.stage_closed
         wizard.record.action_close_ticket()
         self.assertEqual(self.ticket_1.stage_id.name, self.stage_closed.name)
-        self.assertEqual(self.ticket_1.resolution, "<p>Just another resolution</p>")
+        self.assertEqual(
+            self.ticket_1.resolution, Markup("<p>Just another resolution</p>")
+        )
         # check action_complete on fsm.order no ticket
         self.fsm_order_no_ticket.action_complete()
         self.assertEqual(self.fsm_order_no_ticket.stage_id, self.stage_completed)

--- a/helpdesk_mgmt_fieldservice/wizards/fsm_order_close_wizard.py
+++ b/helpdesk_mgmt_fieldservice/wizards/fsm_order_close_wizard.py
@@ -9,7 +9,7 @@ class FSMOrderCloseWizard(models.TransientModel):
     _name = "fsm.order.close.wizard"
     _description = "FSM Close - Option to Close Ticket"
 
-    resolution = fields.Text()
+    resolution = fields.Html()
     team_id = fields.Many2one("helpdesk.ticket.team", string="Helpdesk Team")
     stage_id = fields.Many2one("helpdesk.ticket.stage", string="Stage")
     ticket_id = fields.Many2one("helpdesk.ticket", string="Ticket")


### PR DESCRIPTION
Align with the changes in `fieldservice`:
- https://github.com/OCA/field-service/commit/21b64d83bb59f874ec123b938f8755544eb17534


When solving a fsm order created from a helpdesk ticket, a wizard appears to modify the status of the ticket and to copy the fsm order resolution in the resolution field of the helpdesk ticket. However, due to the mismatch in field types, the UX is broken

<img width="670" height="207" alt="image" src="https://github.com/user-attachments/assets/13cad790-647d-4422-af69-3a34e6f88354" />
