### PR TITLE
[16.0][IMP] helpdesk_motive: allow selecting reasons not assigned to a team

### DIFF
--- a/helpdesk_motive/views/helpdesk_ticket.xml
+++ b/helpdesk_motive/views/helpdesk_ticket.xml
@@ -9,7 +9,7 @@
             <field name="tag_ids" position="before">
                 <field
                     name="motive_id"
-                    domain="[('team_id', '=', team_id)]"
+                    domain="['|' , ('team_id', '=', team_id), ('team_id', '=', False)]"
                     options="{'no_open': True, 'no_create': True}"
                 />
             </field>


### PR DESCRIPTION
in practice, some reasons are generic and not specific to any helpdesk team

this PR extends the field domain to also allow selecting reasons that are not assigned to any team