### PR TITLE
[16.0][IMP] helpdesk_mgmt_project_stage: add option to limit stage sync to single tasks

### DIFF
--- a/helpdesk_mgmt_project_stage/models/helpdesk_ticket_stage.py
+++ b/helpdesk_mgmt_project_stage/models/helpdesk_ticket_stage.py
@@ -13,3 +13,10 @@ class HelpdeskTicketStage(models.Model):
         column1="helpdesk_ticket_stage_id",
         column2="project_task_type_id",
     )
+    sync_limit_single_task = fields.Boolean(
+        string="Sync Only If Single Task",
+        default=False,
+        help="If checked, stage synchronization from Project Tasks to Helpdesk Tickets "
+        "will only happen if the Ticket is linked to exactly one Task. "
+        "If the Ticket has multiple tasks, the stage change will not propagate.",
+    )

--- a/helpdesk_mgmt_project_stage/models/project_task.py
+++ b/helpdesk_mgmt_project_stage/models/project_task.py
@@ -21,4 +21,14 @@ class ProjectTask(models.Model):
                 self.stage_id.ticket_stage_ids & ticket.team_id._get_applicable_stages()
             )[:1]
             if new_stage and ticket.stage_id != new_stage:
+                if (
+                    ticket.stage_id.sync_limit_single_task
+                    or new_stage.sync_limit_single_task
+                ):
+                    task_count = self.env["project.task"].search_count(
+                        [("ticket_ids", "in", ticket.id)]
+                    )
+                    ticket_count = len(self.ticket_ids)
+                    if task_count != 1 or ticket_count != 1:
+                        continue
                 ticket.stage_id = new_stage

--- a/helpdesk_mgmt_project_stage/tests/test_helpdesk_mgmt_project_stage.py
+++ b/helpdesk_mgmt_project_stage/tests/test_helpdesk_mgmt_project_stage.py
@@ -12,19 +12,23 @@ class TestHelpdeskMgmtProjectStage(TransactionCase):
         cls.ticket_stage_progress = cls.env.ref(
             "helpdesk_mgmt.helpdesk_ticket_stage_in_progress"
         )
+        cls.ticket_stage_done = cls.env.ref("helpdesk_mgmt.helpdesk_ticket_stage_done")
         cls.task_stage_progress = cls.env["project.task.type"].create(
             {
                 "name": "stage in progress",
                 "ticket_stage_ids": [Command.link(cls.ticket_stage_progress.id)],
             }
         )
-        cls.ticket_stage_done = cls.env.ref("helpdesk_mgmt.helpdesk_ticket_stage_done")
         cls.task_stage_done = cls.env["project.task.type"].create(
             {
                 "name": "stage done",
                 "ticket_stage_ids": [Command.link(cls.ticket_stage_done.id)],
             }
         )
+        cls.ticket_stage_progress.task_stage_ids = [
+            Command.link(cls.task_stage_progress.id)
+        ]
+        cls.ticket_stage_done.task_stage_ids = [Command.link(cls.task_stage_done.id)]
         cls.project = cls.env["project.project"].create(
             {
                 "name": "Helpdesk project",
@@ -35,7 +39,14 @@ class TestHelpdeskMgmtProjectStage(TransactionCase):
         )
         cls.task = cls.env["project.task"].create(
             {
-                "name": "Ticket task",
+                "name": "Ticket task 1",
+                "project_id": cls.project.id,
+                "stage_id": cls.task_stage_progress.id,
+            }
+        )
+        cls.task_2 = cls.env["project.task"].create(
+            {
+                "name": "Ticket task 2",
                 "project_id": cls.project.id,
                 "stage_id": cls.task_stage_progress.id,
             }
@@ -45,6 +56,7 @@ class TestHelpdeskMgmtProjectStage(TransactionCase):
                 "name": "Ticket",
                 "project_id": cls.project.id,
                 "description": "Change stage",
+                "stage_id": cls.ticket_stage_progress.id,
             }
         )
         cls.user = cls.env.ref("base.user_demo")
@@ -63,3 +75,44 @@ class TestHelpdeskMgmtProjectStage(TransactionCase):
         self.assertEqual(task.stage_id, self.task_stage_progress)
         task.stage_id = False
         self.assertEqual(ticket.stage_id, self.ticket_stage_progress)
+
+    def test_sync_limit_single_task_active_with_multiple_tasks(self):
+        """
+        Test limitation: If Ticket has 2 tasks and restriction is ON,
+        moving ONE task should NOT move the ticket.
+        """
+        self.ticket_stage_progress.sync_limit_single_task = True
+        self.task.write({"ticket_ids": [Command.link(self.ticket.id)]})
+        self.task_2.write({"ticket_ids": [Command.link(self.ticket.id)]})
+        self.task.stage_id = self.task_stage_done
+        self.assertEqual(self.ticket.stage_id, self.ticket_stage_progress)
+
+    def test_sync_limit_single_task_active_with_one_task(self):
+        """
+        Test limitation: If Ticket has only 1 task and restriction is ON,
+        moving the task SHOULD move the ticket normally.
+        """
+        self.ticket_stage_progress.sync_limit_single_task = True
+        self.task.write({"ticket_ids": [Command.link(self.ticket.id)]})
+        self.task_2.write({"ticket_ids": [Command.clear()]})
+        self.task.stage_id = self.task_stage_done
+        self.assertEqual(self.ticket.stage_id, self.ticket_stage_done)
+
+    def test_sync_limit_loop_continue(self):
+        """
+        Test strict coverage of the 'continue' statement.
+        We configure one Task linked to TWO tickets:
+        1. Ticket A (Original): Has multiple tasks -> Should SKIP (hit continue)
+        2. Ticket B (New): Has single task -> Should UPDATE (prove loop continued)
+        """
+        self.ticket_stage_progress.sync_limit_single_task = True
+
+        ticket_b = self.ticket.copy({"name": "Ticket B"})
+
+        self.task.write({"ticket_ids": [Command.link(self.ticket.id)]})
+        self.task_2.write({"ticket_ids": [Command.link(self.ticket.id)]})
+        self.task.write({"ticket_ids": [Command.link(ticket_b.id)]})
+        self.task.stage_id = self.task_stage_done
+
+        self.assertEqual(self.ticket.stage_id, self.ticket_stage_progress)
+        self.assertEqual(ticket_b.stage_id, self.ticket_stage_done)

--- a/helpdesk_mgmt_project_stage/views/helpdesk_ticket_state.xml
+++ b/helpdesk_mgmt_project_stage/views/helpdesk_ticket_state.xml
@@ -13,6 +13,7 @@
                     domain="[('user_id', '=', False)]"
                     options="{'no_create': True}"
                 />
+                <field name="sync_limit_single_task" />
             </group>
         </field>
     </record>


### PR DESCRIPTION
This PR introduces a new configuration, `sync_limit_single_task`, to the Helpdesk Ticket Stage.

**Problem:**
When a ticket is linked to multiple tasks, changing the stage of one task triggers a sync that updates the ticket and subsequently all other linked tasks. This cascade effect is undesirable for parallel works.

**Solution:**
If the new option is enabled on the stage, synchronization from Task to Ticket is skipped if the ticket is linked to more than one task. It ensures the ticket stage only moves when it represents a single unit of work.

cc @WesleyOliveira98 @CristianoMafraJunior @marcelsavegnago @douglascstd 