### PR TITLE
[18.0][FIX] helpdesk_mgmt: add teams to portal domain

### DIFF
--- a/helpdesk_mgmt/controllers/myaccount.py
+++ b/helpdesk_mgmt/controllers/myaccount.py
@@ -104,6 +104,13 @@ class CustomerPortalHelpdesk(CustomerPortal):
             ]
         )
 
+        domain = AND(
+            [
+                domain,
+                [("team_id", "in", request.env["helpdesk.ticket.team"].search([]).ids)],
+            ]
+        )
+
         # count for pager
         ticket_count = HelpdeskTicket.search_count(domain)
         # pager


### PR DESCRIPTION
Before this PR whenever you create a ticket with a portal user as contact and assign a team without `show_in_portal`, the next error raise, not allowing you to see any ticket in `/my/tickets`.
<img width="1022" height="304" alt="image" src="https://github.com/user-attachments/assets/f29b93dd-d0fd-434d-9e05-2c0ecb423524" />
The solution proposed here is filtering out non visible team tickets.
@Tecnativa TT60091
@pedrobaeza @david-banon-tecnativa @victoralmau 