### PR TITLE
[16.0][IMP] helpdesk_mgmt_fieldservice: review fsm_order_close_wizard security

### DIFF
--- a/helpdesk_mgmt_fieldservice/models/fsm_order.py
+++ b/helpdesk_mgmt_fieldservice/models/fsm_order.py
@@ -3,6 +3,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from odoo import fields, models
+from odoo.exceptions import AccessError
 
 
 class FSMOrder(models.Model):
@@ -10,10 +11,23 @@ class FSMOrder(models.Model):
 
     ticket_id = fields.Many2one("helpdesk.ticket", string="Ticket", tracking=True)
 
+    def _check_tickets_access(self):
+        """The current user can access the tickets of `self`."""
+        tickets = self.ticket_id
+        try:
+            tickets.check_access_rights("write")
+            tickets.check_access_rule("write")
+        except AccessError:
+            can_access_tickets = False
+        else:
+            can_access_tickets = True
+        return can_access_tickets
+
     def action_complete(self):
         res = super().action_complete()
         if (
-            not self.ticket_id.stage_id.closed
+            self._check_tickets_access()
+            and not self.ticket_id.stage_id.closed
             and self.ticket_id.fsm_order_ids
             and all(self.ticket_id.mapped("fsm_order_ids.stage_id.is_closed"))
         ):
@@ -24,7 +38,6 @@ class FSMOrder(models.Model):
                 "target": "new",
                 "context": {
                     "default_ticket_id": self.ticket_id.id,
-                    "default_team_id": self.ticket_id.team_id.id,
                     "default_resolution": self.resolution,
                 },
             }

--- a/helpdesk_mgmt_fieldservice/security/ir.model.access.csv
+++ b/helpdesk_mgmt_fieldservice/security/ir.model.access.csv
@@ -1,3 +1,3 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
 access_helpdesk_ticket_fsm_user,helpdesk.ticket.fsm.user,model_helpdesk_ticket,fieldservice.group_fsm_user,1,0,0,0
-access_fsm_order_close_wizard,fsm.order.close.wizard,model_fsm_order_close_wizard,fieldservice.group_fsm_user,1,1,1,0
+access_fsm_order_close_wizard,fsm.order.close.wizard,model_fsm_order_close_wizard,fieldservice.group_fsm_user_own,1,1,1,0

--- a/helpdesk_mgmt_fieldservice/tests/test_helpdesk_ticket_fsm_order.py
+++ b/helpdesk_mgmt_fieldservice/tests/test_helpdesk_ticket_fsm_order.py
@@ -4,6 +4,8 @@
 from odoo.exceptions import ValidationError
 from odoo.tests.common import Form, TransactionCase
 
+from odoo.addons.mail.tests.common import mail_new_test_user
+
 
 class TestHelpdeskTicketFSMOrder(TransactionCase):
     @classmethod
@@ -15,6 +17,13 @@ class TestHelpdeskTicketFSMOrder(TransactionCase):
         cls.partner = cls.env["res.partner"].create({"name": "Partner 1"})
         cls.user_demo = cls.env.ref("base.user_demo")
         cls.HelpdeskTicketTeam = cls.env["helpdesk.ticket.team"]
+        cls.all_doc_group_xmlid = "fieldservice.group_fsm_user"
+        cls.own_doc_group_xmlid = "fieldservice.group_fsm_user_own"
+        cls.own_doc_user = mail_new_test_user(
+            cls.env,
+            login="test fieldservice user own documents",
+            groups=cls.own_doc_group_xmlid,
+        )
         cls.fsm_team = cls.env["fsm.team"].create({"name": "FSM Team"})
         cls.fsm_stage_new = cls.env.ref("fieldservice.fsm_stage_new")
         cls.fsm_stage_cancelled = cls.env.ref("fieldservice.fsm_stage_cancelled")
@@ -134,7 +143,6 @@ class TestHelpdeskTicketFSMOrder(TransactionCase):
             action_complete_last_order["context"],
             {
                 "default_ticket_id": self.ticket_1.id,
-                "default_team_id": self.team_id.id,
                 "default_resolution": "Just another resolution",
             },
         )
@@ -174,3 +182,20 @@ class TestHelpdeskTicketFSMOrder(TransactionCase):
             ValidationError, "Please complete all service orders"
         ):
             self.ticket_1.stage_id = self.stage_closed
+
+    def test_user_own_close_wizard(self):
+        """A user that can only access their own documents,
+        can close an order."""
+        # Arrange
+        user = self.own_doc_user
+        fsm_order = self._create_ticket_fsm_orders(self.ticket_1)
+        # pre-condition
+        self.assertNotEqual(fsm_order.stage_id, self.stage_completed)
+        self.assertTrue(user.has_group(self.own_doc_group_xmlid))
+        self.assertFalse(user.has_group(self.all_doc_group_xmlid))
+
+        # Act
+        fsm_order.with_user(user).action_complete()
+
+        # Assert
+        self.assertEqual(fsm_order.stage_id, self.stage_completed)

--- a/helpdesk_mgmt_fieldservice/wizards/fsm_order_close_wizard.py
+++ b/helpdesk_mgmt_fieldservice/wizards/fsm_order_close_wizard.py
@@ -10,7 +10,6 @@ class FSMOrderCloseWizard(models.TransientModel):
     _description = "FSM Close - Option to Close Ticket"
 
     resolution = fields.Text()
-    team_id = fields.Many2one("helpdesk.ticket.team", string="Helpdesk Team")
     stage_id = fields.Many2one("helpdesk.ticket.stage", string="Stage")
     ticket_id = fields.Many2one("helpdesk.ticket", string="Ticket")
 

--- a/helpdesk_mgmt_fieldservice/wizards/fsm_order_close_wizard.xml
+++ b/helpdesk_mgmt_fieldservice/wizards/fsm_order_close_wizard.xml
@@ -11,13 +11,7 @@
                   There is an open Ticket, would you like to update the related ticket?
               </div>
               <group>
-                  <field name="team_id" invisible="1" />
                   <field name="ticket_id" invisible="1" />
-<!--                  <field name="stage_id"-->
-<!--                         string="Ticket Stage"-->
-<!--                         required="1"-->
-<!--                         domain="[('team_ids', '=', team_id)]"-->
-<!--                         options="{'no_create': True, 'no_open': True, 'no_create_edit': True}"/>-->
                   <field
                         name="stage_id"
                         string="Ticket Stage"


### PR DESCRIPTION
Proposing again a fix that was already proposed for `14.0` in https://github.com/OCA/helpdesk/pull/593 and https://github.com/OCA/helpdesk/pull/404, hoping the third time's the charm :four_leaf_clover:
I also added a test :rocket:

---

This commit reviews the security rules around the fsm_order_close_wizard.

The "Complete" button on the fsm.order triggered an access error for fieldservice.group_fsm_user_own. The commit allows fieldservice.group_fsm_user_own to use the wizard as well. However, the wizard is now only shown if the user also has write permission on the specific ticket (so as to play nice with a variety of setups, including helpdesk_mgmt.group_helpdesk_user_own).

If the user has permission to write on the ticket, the wizard will be shown as before; otherwise it will simply be skipped, but the fsm.order will be closed as it should.

There's also some code cleanup on the wizard, such as removing the unused team_id field.