### PR TITLE
[18.0][IMP] helpdesk_mgmt: Add exclude_from_count field on stages

### DIFF
--- a/helpdesk_mgmt/models/helpdesk_ticket_stage.py
+++ b/helpdesk_mgmt/models/helpdesk_ticket_stage.py
@@ -42,6 +42,13 @@ class HelpdeskTicketStage(models.Model):
         domain="['|', ('company_id', '=', False), ('company_id', '=', company_id)]",
     )
 
+    exclude_from_count = fields.Boolean(
+        string="Exclude from Counter",
+        default=False,
+        help="If checked, tickets in this stage will not be counted "
+        "in the team dashboard",
+    )
+
     @api.onchange("closed")
     def _onchange_closed(self):
         if not self.closed:

--- a/helpdesk_mgmt/models/helpdesk_ticket_team.py
+++ b/helpdesk_mgmt/models/helpdesk_ticket_team.py
@@ -110,11 +110,17 @@ class HelpdeskTeam(models.Model):
             ]
         return self.env["helpdesk.ticket.stage"].search(domain)
 
-    @api.depends("ticket_ids", "ticket_ids.stage_id")
+    @api.depends("ticket_ids", "ticket_ids.stage_id", "ticket_ids.closed")
     def _compute_todo_tickets(self):
+        excluded_stages = self.env["helpdesk.ticket.stage"].search(
+            [("exclude_from_count", "=", True)]
+        )
         ticket_model = self.env["helpdesk.ticket"]
+        base_domain = [("team_id", "in", self.ids), ("closed", "=", False)]
+        if excluded_stages:
+            base_domain.append(("stage_id", "not in", excluded_stages.ids))
         fetch_data = ticket_model.read_group(
-            [("team_id", "in", self.ids), ("closed", "=", False)],
+            base_domain,
             ["team_id", "user_id", "unattended", "priority"],
             ["team_id", "user_id", "unattended", "priority"],
             lazy=False,

--- a/helpdesk_mgmt/models/helpdesk_ticket_team.py
+++ b/helpdesk_mgmt/models/helpdesk_ticket_team.py
@@ -110,11 +110,20 @@ class HelpdeskTeam(models.Model):
             ]
         return self.env["helpdesk.ticket.stage"].search(domain)
 
-    @api.depends("ticket_ids", "ticket_ids.stage_id")
+    @api.depends("ticket_ids", "ticket_ids.stage_id", "ticket_ids.closed")
     def _compute_todo_tickets(self):
+        excluded_stages = self.env["helpdesk.ticket.stage"].search(
+            [("exclude_from_count", "=", True)]
+        )
+
         ticket_model = self.env["helpdesk.ticket"]
+        base_domain = [("team_id", "in", self.ids), ("closed", "=", False)]
+
+        if excluded_stages:
+            base_domain.append(("stage_id", "not in", excluded_stages.ids))
+
         fetch_data = ticket_model.read_group(
-            [("team_id", "in", self.ids), ("closed", "=", False)],
+            base_domain,
             ["team_id", "user_id", "unattended", "priority"],
             ["team_id", "user_id", "unattended", "priority"],
             lazy=False,

--- a/helpdesk_mgmt/tests/test_helpdesk_ticket_team.py
+++ b/helpdesk_mgmt/tests/test_helpdesk_ticket_team.py
@@ -115,3 +115,33 @@ class TestHelpdeskTicketTeam(TestHelpdeskTicketBase):
         dashboard = self.env["helpdesk.ticket.team"]._retrieve_dashboard()
         self.assertEqual(dashboard[0]["value"], 0)
         self.assertEqual(dashboard[1]["value"], 1)
+
+    def test_exclude_stage_from_count(self):
+        """Test that tickets in excluded stages are not counted"""
+        stage_excluded = self.env["helpdesk.ticket.stage"].create(
+            {
+                "name": "Waiting for Customer",
+                "exclude_from_count": True,
+            }
+        )
+        initial_count = self.team_a.todo_ticket_count
+        self.env["helpdesk.ticket"].create(
+            {
+                "name": "Ticket in excluded stage",
+                "description": "Test ticket",
+                "team_id": self.team_a.id,
+                "stage_id": stage_excluded.id,
+            }
+        )
+        self.assertEqual(
+            self.team_a.todo_ticket_count,
+            initial_count,
+            "Helpdesk Ticket: Tickets in excluded stages should not be counted.",
+        )
+        stage_excluded.exclude_from_count = False
+        self.team_a.invalidate_recordset(["todo_ticket_count"])
+        self.assertEqual(
+            self.team_a.todo_ticket_count,
+            initial_count + 1,
+            "Helpdesk Ticket: Tickets should be counted when stage is not excluded.",
+        )

--- a/helpdesk_mgmt/views/helpdesk_ticket_stage_views.xml
+++ b/helpdesk_mgmt/views/helpdesk_ticket_stage_views.xml
@@ -60,6 +60,7 @@
                             <field name="closed" />
                             <field name="close_from_portal" invisible="not closed" />
                             <field name="fold" />
+                            <field name="exclude_from_count" />
                             <field name="unattended" />
                         </group>
                     </group>
@@ -75,6 +76,7 @@
             <list>
                 <field name="sequence" widget="handle" />
                 <field name="name" />
+                <field name="exclude_from_count" optional="show" />
                 <field name="mail_template_id" />
                 <field name="team_ids" widget="many2many_tags" />
                 <field


### PR DESCRIPTION
## Description

This PR adds the ability to exclude certain ticket stages from the team dashboard counters.

## Use Case

Some stages like "Waiting for Customer Feedback" or "On Hold" should not be counted in the "TODO" counter as they are pending external action and don't represent actual work in progress for the team.

## Changes

- Add `exclude_from_count` boolean field on `helpdesk.ticket.stage`
- Modify `_compute_todo_tickets` to filter out excluded stages
- Add UI elements in form and tree views for the new field

## How to Test

1. Install/upgrade the `helpdesk_mgmt` module
2. Go to **Helpdesk → Configuration → Stages**
3. Open a stage 
4. Check the "Exclude from Counter" checkbox
5. Create tickets in this stage
6. Verify that these tickets are NOT counted in the team dashboard "X TODO" counter
7. Uncheck the box and verify the counter updates correctly

## Screenshots

<img width="1894" height="412" alt="Screenshot 2026-01-21 at 11-29-13 Odoo - Waiting for Customer" src="https://github.com/user-attachments/assets/62f7c405-040f-4169-9a2d-bcf497598e36" />

<img width="1909" height="381" alt="Screenshot 2026-01-21 at 11-29-26 Odoo - Stages" src="https://github.com/user-attachments/assets/47b809a1-e857-4979-8492-b7c745cdec4e" />

<img width="1137" height="642" alt="Screenshot 2026-01-21 at 11-29-38 Odoo - Helpdesk Ticket" src="https://github.com/user-attachments/assets/954eef70-fecd-4752-91af-994637ef7bf5" />

<img width="326" height="373" alt="Screenshot 2026-01-21 at 11-29-47 Odoo - Dashboard" src="https://github.com/user-attachments/assets/c6870ed4-d121-4b86-881f-95a0f099f5d6" />