### PR TITLE
[18.0][FIX] helpdesk_mgmt_timesheet: Fix With activity today filter

### DIFF
--- a/helpdesk_mgmt_timesheet/views/helpdesk_ticket_view.xml
+++ b/helpdesk_mgmt_timesheet/views/helpdesk_ticket_view.xml
@@ -24,7 +24,7 @@
                     name="with_activity_today"
                     string="With activity today"
                     groups="hr_timesheet.group_hr_timesheet_user"
-                    domain="[('last_timesheet_activity', '=', datetime.datetime.today())]"
+                    domain="[('last_timesheet_activity', '=', context_today())]"
                 />
                 <separator />
             </filter>


### PR DESCRIPTION
Right now the filter "With activity today" is raising an error when trying to access` datetime.datetime`
@Tecnativa TT60514
@victoralmau @david-banon-tecnativa 