### PR TITLE
[16.0][REF] helpdesk_mgmt_project_stage: domain task_stage_ids

### DIFF
--- a/helpdesk_mgmt_project_stage/views/helpdesk_ticket_state.xml
+++ b/helpdesk_mgmt_project_stage/views/helpdesk_ticket_state.xml
@@ -7,7 +7,12 @@
         <field name="inherit_id" ref="helpdesk_mgmt.view_helpdesk_ticket_stage_form" />
         <field name="arch" type="xml">
             <group name="main_right" position="inside">
-                <field name="task_stage_ids" widget="many2many_tags" />
+                <field
+                    name="task_stage_ids"
+                    widget="many2many_tags"
+                    domain="[('user_id', '=', False)]"
+                    options="{'no_create': True}"
+                />
             </group>
         </field>
     </record>


### PR DESCRIPTION
@Escodoo P&D-174
We add a domain and no_create to make the mapping between Helpdesk ticket stages and Project task stages safe and predictable

cc @douglascstd @WesleyOliveira98 @kaynnan @marcelsavegnago 