### PR TITLE
[18.0][FIX] helpdesk_mgmt_project: project not associate at task creation

### DIFF
--- a/helpdesk_mgmt_project/views/helpdesk_ticket_view.xml
+++ b/helpdesk_mgmt_project/views/helpdesk_ticket_view.xml
@@ -41,6 +41,7 @@
                     domain="[('project_id', '=', project_id)]"
                     invisible="not project_id"
                     context="{'default_project_id': project_id}"
+                    options="{'no_quick_create': True}"
                     groups="project.group_project_user"
                 />
                 <t groups="project.group_project_milestone">


### PR DESCRIPTION
The project is not associate when create ticket without modification. The context not working.
A solution is to disable quick creation. Or maybe we can fix it without disable it?

The option `Create "Test creation"` not working, only `Create and edit...`
This commit disable first option
<img width="462" height="364" alt="image" src="https://github.com/user-attachments/assets/397c5eac-21e4-4446-aeea-2e10c186ed45" />

This is the error when selection `Create "Test creation"`
Project is missing
<img width="639" height="208" alt="image" src="https://github.com/user-attachments/assets/74a2f913-38de-4dd2-88da-bf476d3e5336" />
