### PR TITLE
[16.0][IMP] helpdesk_mgmt_sale: add button create ticket and display sales

### DIFF
--- a/helpdesk_mgmt_sale/models/helpdesk_ticket.py
+++ b/helpdesk_mgmt_sale/models/helpdesk_ticket.py
@@ -30,10 +30,11 @@ class HelpdeskTicket(models.Model):
         if self.env.context.get("from_sale_order"):
             # only one ticket is possible here
             for sale in tickets.sale_order_ids:
-                sale.message_post(
-                    body=_(
-                        f"Helpdesk Ticket {tickets.name} created by {self.env.user.name}"
-                    )
-                )
+                sale.message_post(body=self._get_default_message_creation(tickets))
 
         return tickets
+
+    def _get_default_message_creation(self, tickets):
+        return _(
+            f"Helpdesk Ticket {tickets.display_name} created by {self.env.user.name}"
+        )

--- a/helpdesk_mgmt_sale/models/helpdesk_ticket.py
+++ b/helpdesk_mgmt_sale/models/helpdesk_ticket.py
@@ -1,4 +1,4 @@
-from odoo import api, fields, models
+from odoo import _, api, fields, models
 
 
 class HelpdeskTicket(models.Model):
@@ -23,3 +23,17 @@ class HelpdeskTicket(models.Model):
             "default_partner_id": self.partner_id.id,
         }
         return action
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        tickets = super().create(vals_list)
+        if self.env.context.get("from_sale_order"):
+            # only one ticket is possible here
+            for sale in tickets.sale_order_ids:
+                sale.message_post(
+                    body=_(
+                        f"Helpdesk Ticket {tickets.name} created by {self.env.user.name}"
+                    )
+                )
+
+        return tickets

--- a/helpdesk_mgmt_sale/models/sale_order.py
+++ b/helpdesk_mgmt_sale/models/sale_order.py
@@ -13,3 +13,22 @@ class SaleOrder(models.Model):
     def _compute_ticket_count(self):
         for order in self:
             order.ticket_count = len(order.ticket_ids)
+
+    def action_create_helpdesk_ticket(self):
+        self.ensure_one()
+
+        return {
+            "type": "ir.actions.act_window",
+            "name": "Create Helpdesk ticket",
+            "res_model": "helpdesk.ticket",
+            "view_mode": "form",
+            "view_id": self.env.ref("helpdesk_mgmt.ticket_view_form").id,
+            "target": "new",
+            "context": {
+                "default_partner_id": self.partner_id.id,
+                "default_name": self.name,
+                "default_origin": self.name,
+                "default_sale_order_ids": [(4, self.id)],
+                "from_sale_order": True,
+            },
+        }

--- a/helpdesk_mgmt_sale/tests/test_helpdesk_ticket.py
+++ b/helpdesk_mgmt_sale/tests/test_helpdesk_ticket.py
@@ -7,6 +7,7 @@ class TestHelpdeskTicketSale(BaseCommon):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
+        cls.Ticket = cls.env["helpdesk.ticket"]
         cls.partner = cls.env["res.partner"].create(
             {"name": "Test Partner", "email": "testpartner@example.com"}
         )
@@ -53,3 +54,42 @@ class TestHelpdeskTicketSale(BaseCommon):
         self.assertEqual(
             action["context"]["default_ticket_ids"], [(4, [self.ticket.id])]
         )
+
+    def test_create_ticket_without_context(self):
+        self.Ticket.create(
+            {
+                "name": "Test Ticket",
+                "sale_order_ids": [(6, 0, [self.sale_order_1.id])],
+                "description": "Test Helpdesk Ticket",
+            }
+        )
+        messages = self.sale_order_1.message_ids.filtered(
+            lambda m: "Helpdesk Ticket" in (m.body or "")
+        )
+        self.assertFalse(messages, "No message should be posted without context")
+
+    def test_create_ticket_with_context(self):
+        ticket = self.Ticket.with_context(from_sale_order=True).create(
+            {
+                "name": "Ticket Context",
+                "sale_order_ids": [(6, 0, [self.sale_order_2.id])],
+                "description": "Test Helpdesk Ticket",
+            }
+        )
+
+        messages = self.sale_order_2.message_ids.filtered(
+            lambda m: ticket.name in (m.body or "")
+        )
+
+        self.assertTrue(messages, "A message should be posted on the sale order")
+        self.assertIn(self.env.user.name, messages[0].body)
+
+    def test_action_context_values(self):
+        action = self.sale_order_1.action_create_helpdesk_ticket()
+        ctx = action["context"]
+
+        self.assertEqual(ctx["default_partner_id"], self.partner.id)
+        self.assertEqual(ctx["default_name"], self.sale_order_1.name)
+        self.assertEqual(ctx["default_origin"], self.sale_order_1.name)
+        self.assertEqual(ctx["default_sale_order_ids"], [(4, self.sale_order_1.id)])
+        self.assertTrue(ctx["from_sale_order"])

--- a/helpdesk_mgmt_sale/views/helpdesk_ticket_views.xml
+++ b/helpdesk_mgmt_sale/views/helpdesk_ticket_views.xml
@@ -17,6 +17,9 @@
                     <field string="Sale Orders" name="so_count" widget="statinfo" />
                 </button>
             </xpath>
+            <field name="channel_id" position="after">
+                <field name="sale_order_ids" widget="many2many_tags" />
+            </field>
         </field>
     </record>
     <record id="action_helpdesk_ticket" model="ir.actions.act_window">

--- a/helpdesk_mgmt_sale/views/sale_order_views.xml
+++ b/helpdesk_mgmt_sale/views/sale_order_views.xml
@@ -28,6 +28,14 @@
                     <field string="Tickets" name="ticket_count" widget="statinfo" />
                 </button>
             </xpath>
+            <xpath expr="//header" position="inside">
+                <button
+                    name="action_create_helpdesk_ticket"
+                    type="object"
+                    string="Créer un ticket"
+                    class="btn btn-primary"
+                />
+        </xpath>
         </field>
     </record>
 </odoo>

--- a/helpdesk_mgmt_sale/views/sale_order_views.xml
+++ b/helpdesk_mgmt_sale/views/sale_order_views.xml
@@ -32,7 +32,7 @@
                 <button
                     name="action_create_helpdesk_ticket"
                     type="object"
-                    string="Créer un ticket"
+                    string="Create a ticket"
                     class="btn btn-primary"
                 />
         </xpath>


### PR DESCRIPTION
add button to create a ticket with value of active sale order.
display and default filled sale_order_ids.