### PR TITLE
[18.0][FIX] helpdesk_mgmt_rating: Send the rating email immediately

### DIFF
--- a/helpdesk_mgmt_rating/models/helpdesk_ticket.py
+++ b/helpdesk_mgmt_rating/models/helpdesk_ticket.py
@@ -37,7 +37,7 @@ class HelpdeskTicket(models.Model):
         if "stage_id" in vals and vals.get("stage_id"):
             stage = self.env["helpdesk.ticket.stage"].browse(vals.get("stage_id"))
             if stage.rating_mail_template_id:
-                self._send_ticket_rating_mail(force_send=False)
+                self._send_ticket_rating_mail(force_send=True)
         return res
 
     def _send_ticket_rating_mail(self, force_send=False):


### PR DESCRIPTION
FWP from 17.0: https://github.com/OCA/helpdesk/pull/951

Send the rating email immediately

Similar to what happens in project tasks: https://github.com/odoo/odoo/blob/58fb9dc7e4ce20e8f2458f25973e1f4b8f87459b/addons/project/models/project_task.py#L1165

Please @pedrobaeza can you review it?

@Tecnativa TT61157