### PR TITLE
[17.0][IMP] helpdesk_mgmt: allows team leader to follow tickets automatically

### DIFF
--- a/helpdesk_mgmt/models/helpdesk_ticket.py
+++ b/helpdesk_mgmt/models/helpdesk_ticket.py
@@ -223,7 +223,13 @@ class HelpdeskTicket(models.Model):
                 )
                 if channel_email_id:
                     vals["channel_id"] = channel_email_id.id
-        return super().create(vals_list)
+        tickets = super().create(vals_list)
+        for ticket in tickets.filtered(
+            lambda t: t.team_id.add_leader_as_follower and t.team_id.user_id.partner_id
+        ):
+            ticket.message_subscribe(partner_ids=[ticket.team_id.user_id.partner_id.id])
+
+        return tickets
 
     def copy(self, default=None):
         self.ensure_one()
@@ -244,7 +250,16 @@ class HelpdeskTicket(models.Model):
                     vals["closed_date"] = now
             if vals.get("user_id"):
                 vals["assigned_date"] = now
-        return super().write(vals)
+        res = super().write(vals)
+        if "team_id" in vals:
+            for ticket in self.filtered(
+                lambda t: t.team_id.add_leader_as_follower
+                and t.team_id.user_id.partner_id
+            ):
+                ticket.message_subscribe(
+                    partner_ids=[ticket.team_id.user_id.partner_id.id]
+                )
+        return res
 
     def action_duplicate_tickets(self):
         for ticket in self.browse(self.env.context["active_ids"]):

--- a/helpdesk_mgmt/models/helpdesk_ticket_team.py
+++ b/helpdesk_mgmt/models/helpdesk_ticket_team.py
@@ -75,6 +75,11 @@ class HelpdeskTeam(models.Model):
         compute="_compute_complete_name", store=True, recursive=True
     )
     parent_path = fields.Char(index=True, unaccent=False)
+    add_leader_as_follower = fields.Boolean(
+        string="Leader follows tickets",
+        default=False,
+        help="If enabled, the team leader will automatically follow new tickets.",
+    )
 
     @api.depends("name", "parent_id.complete_name")
     def _compute_complete_name(self):

--- a/helpdesk_mgmt/tests/test_helpdesk_ticket.py
+++ b/helpdesk_mgmt/tests/test_helpdesk_ticket.py
@@ -111,6 +111,40 @@ class TestHelpdeskTicket(TestHelpdeskTicketBase):
             "have the same number than the origin ticket.",
         )
 
+    def test_helpdesk_ticket_team_leader_follower_on_create(self):
+        self.team_a.write(
+            {
+                "add_leader_as_follower": True,
+                "user_id": self.user_own.id,
+            }
+        )
+        new_ticket = self.env["helpdesk.ticket"].create(
+            {
+                "name": "Ticket with team leader follower",
+                "description": "Description",
+                "team_id": self.team_a.id,
+            }
+        )
+        self.assertIn(self.user_own.partner_id, new_ticket.message_partner_ids)
+
+    def test_helpdesk_ticket_team_leader_follower_on_team_change(self):
+        self.team_b.write(
+            {
+                "add_leader_as_follower": True,
+                "user_id": self.user_team.id,
+            }
+        )
+        new_ticket = self.env["helpdesk.ticket"].create(
+            {
+                "name": "Ticket changing team",
+                "description": "Description",
+                "team_id": self.team_a.id,
+            }
+        )
+        self.assertNotIn(self.user_team.partner_id, new_ticket.message_partner_ids)
+        new_ticket.write({"team_id": self.team_b.id})
+        self.assertIn(self.user_team.partner_id, new_ticket.message_partner_ids)
+
     def test_helpdesk_ticket_message_new(self):
         Partner = self.env["res.partner"]
         Ticket = self.env["helpdesk.ticket"]

--- a/helpdesk_mgmt/views/helpdesk_ticket_team_views.xml
+++ b/helpdesk_mgmt/views/helpdesk_ticket_team_views.xml
@@ -102,6 +102,7 @@
                                 groups="base.group_multi_company"
                             />
                             <field name="show_in_portal" />
+                            <field name="add_leader_as_follower" />
                             <field name="category_ids" widget="many2many_tags" />
                         </group>
                         <group name="right">


### PR DESCRIPTION
Add an optional setting in helpdesk teams to automatically subscribe the team leader as a follower of tickets belonging to that team.

<img width="1202" height="865" alt="imagen" src="https://github.com/user-attachments/assets/486ef60a-3aaf-49a0-bb2f-b88986785a04" />
