### PR TITLE
[18.0][FIX] helpdesk_mgmt_project: Remove store from counts

### DIFF
--- a/helpdesk_mgmt_project/models/project.py
+++ b/helpdesk_mgmt_project/models/project.py
@@ -7,7 +7,7 @@ class ProjectProject(models.Model):
     ticket_ids = fields.One2many(
         comodel_name="helpdesk.ticket", inverse_name="project_id", string="Tickets"
     )
-    ticket_count = fields.Integer(compute="_compute_ticket_count", store=True)
+    ticket_count = fields.Integer(compute="_compute_ticket_count")
     label_tickets = fields.Char(
         string="Use Tickets as",
         default=lambda self: self.env._("Tickets"),
@@ -15,7 +15,7 @@ class ProjectProject(models.Model):
         help="Gives label to tickets on project's kanban view.",
     )
     todo_ticket_count = fields.Integer(
-        string="Number of tickets", compute="_compute_ticket_count", store=True
+        string="Number of tickets", compute="_compute_ticket_count"
     )
 
     @api.depends("ticket_ids", "ticket_ids.stage_id")

--- a/helpdesk_mgmt_project/models/project_task.py
+++ b/helpdesk_mgmt_project/models/project_task.py
@@ -7,7 +7,7 @@ class ProjectTask(models.Model):
     ticket_ids = fields.One2many(
         comodel_name="helpdesk.ticket", inverse_name="task_id", string="Tickets"
     )
-    ticket_count = fields.Integer(compute="_compute_ticket_count", store=True)
+    ticket_count = fields.Integer(compute="_compute_ticket_count")
     label_tickets = fields.Char(
         string="Use Tickets as",
         default=lambda self: self.env._("Tickets"),
@@ -15,7 +15,7 @@ class ProjectTask(models.Model):
         help="Gives label to tickets on project's kanban view.",
     )
     todo_ticket_count = fields.Integer(
-        string="Number of tickets", compute="_compute_ticket_count", store=True
+        string="Number of tickets", compute="_compute_ticket_count"
     )
 
     @api.depends("ticket_ids", "ticket_ids.stage_id")

--- a/helpdesk_mgmt_project/views/project_task_view.xml
+++ b/helpdesk_mgmt_project/views/project_task_view.xml
@@ -27,7 +27,7 @@
                 <filter
                     string="Open Tickets"
                     name="open_tickets"
-                    domain="[('todo_ticket_count', '&gt;', 0)]"
+                    domain="[('ticket_ids', '!=', False), ('ticket_ids.closed', '=', False)]"
                     groups="helpdesk_mgmt.group_helpdesk_user_own"
                 />
             </xpath>

--- a/helpdesk_mgmt_project/views/project_view.xml
+++ b/helpdesk_mgmt_project/views/project_view.xml
@@ -50,7 +50,7 @@
                 <filter
                     string="Open Tickets"
                     name="open_tickets"
-                    domain="[('todo_ticket_count', '&gt;', 0)]"
+                    domain="[('ticket_ids', '!=', False), ('ticket_ids.closed', '=', False)]"
                     groups="helpdesk_mgmt.group_helpdesk_user_own"
                 />
             </xpath>


### PR DESCRIPTION
Having count fields that get computed on the creation of a different record can lead into a concurrence error rolling back the records created, in this case the helpdesk tickets. Didn't find any other reason for the stores than the domain in the views so I adapt them to a similar one.

@Tecnativa TT61446
@pedrobaeza @victoralmau 