### PR TITLE
[18.0][FIX]helpdesk_ticket_close_inactive: relation definition of ticket_stage_ids

### DIFF
--- a/helpdesk_ticket_close_inactive/models/helpdesk_ticket_team.py
+++ b/helpdesk_ticket_close_inactive/models/helpdesk_ticket_team.py
@@ -31,6 +31,7 @@ class HelpdeskTicketTeam(models.Model):
     )
     ticket_stage_ids = fields.Many2many(
         comodel_name="helpdesk.ticket.stage",
+        relation="helpdesk_team_stage_closing_ticket_filter_rel",
         string="Ticket Stage",
         help="The cronjob will check for inactivity in \
         tickets that are in these stages.",

--- a/helpdesk_ticket_close_inactive/views/helpdesk_ticket_team.xml
+++ b/helpdesk_ticket_close_inactive/views/helpdesk_ticket_team.xml
@@ -46,11 +46,7 @@
                             />
                         </group>
                         <group name="categories" string="Ticket Category Filter">
-                            <field
-                                name="ticket_category_ids"
-                                widget="many2many_tags"
-                                required="close_inactive_tickets"
-                            />
+                            <field name="ticket_category_ids" widget="many2many_tags" />
                         </group>
                     </group>
                 </page>


### PR DESCRIPTION
- fix relation definition of ticket_stage_ids field on helpdesk team
- fix not required ticket_category_ids

Fix proposition based @rrebollo [fix](https://github.com/OCA/helpdesk/pull/863)
previous issue: https://github.com/OCA/helpdesk/issues/839