### PR TITLE
[18.0][IMP] helpdesk_mgmt: Add default fields to partner_id field

### DIFF
--- a/helpdesk_mgmt/views/helpdesk_ticket_views.xml
+++ b/helpdesk_mgmt/views/helpdesk_ticket_views.xml
@@ -246,7 +246,10 @@
                             <field name="channel_id" />
                         </group>
                         <group>
-                            <field name="partner_id" />
+                            <field
+                                name="partner_id"
+                                context="{'default_name': partner_name, 'default_email': partner_email, 'show_vat': True}"
+                            />
                             <field name="partner_name" />
                             <field name="partner_email" />
                             <field name="category_id" />


### PR DESCRIPTION
FWP from 17.0: https://github.com/OCA/helpdesk/pull/985

Add default fields to partner_id field

Similar to what happens with CRM, the following changes are added to the partner_id field:
- Define a context with the default values for the fields that exist in the ticket

Please @pedrobaeza and @Andrii9090-tecnativa can you review it?

@Tecnativa TT62128