### PR TITLE
[18.0][FIX] helpdesk_mgmt_project: explicitly assign project to task

### DIFF
--- a/helpdesk_mgmt_project/models/helpdesk_ticket.py
+++ b/helpdesk_mgmt_project/models/helpdesk_ticket.py
@@ -34,3 +34,19 @@ class HelpdeskTicket(models.Model):
         for record in self:
             if record.task_id.project_id != record.project_id:
                 record.task_id = False
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        tickets = super().create(vals_list)
+        for ticket in tickets:
+            if ticket.task_id and not ticket.task_id.project_id and ticket.project_id:
+                ticket.task_id.project_id = ticket.project_id
+        return tickets
+
+    def write(self, vals):
+        res = super().write(vals)
+        if "task_id" in vals or "project_id" in vals:
+            for ticket in self:
+                if ticket.task_id and not ticket.task_id.project_id and ticket.project_id:
+                    ticket.task_id.project_id = ticket.project_id
+        return res

--- a/helpdesk_mgmt_project/models/helpdesk_ticket.py
+++ b/helpdesk_mgmt_project/models/helpdesk_ticket.py
@@ -47,6 +47,10 @@ class HelpdeskTicket(models.Model):
         res = super().write(vals)
         if "task_id" in vals or "project_id" in vals:
             for ticket in self:
-                if ticket.task_id and not ticket.task_id.project_id and ticket.project_id:
+                if (
+                    ticket.task_id
+                    and not ticket.task_id.project_id
+                    and ticket.project_id
+                ):
                     ticket.task_id.project_id = ticket.project_id
         return res

--- a/helpdesk_mgmt_project/tests/test_helpdesk_ticket.py
+++ b/helpdesk_mgmt_project/tests/test_helpdesk_ticket.py
@@ -1,5 +1,6 @@
-from odoo.tools.safe_eval import safe_eval
 from odoo.tests import Form
+from odoo.tools.safe_eval import safe_eval
+
 from odoo.addons.helpdesk_mgmt.tests.common import TestHelpdeskTicketBase
 
 
@@ -178,7 +179,7 @@ class TestHelpdeskTicketProject(TestHelpdeskTicketBase):
 
     def test_create_task_from_ticket(self):
         """Test creating a task from the ticket simulating UI context/RPC."""
-        
+
         ticket_form = Form(self.env["helpdesk.ticket"])
         ticket_form.name = "Test Ticket for Task Creation"
         ticket_form.project_id = self.project1
@@ -189,11 +190,12 @@ class TestHelpdeskTicketProject(TestHelpdeskTicketBase):
         task_form = Form(self.env["project.task"])
         task_form.name = "Task generated from ticket"
         task = task_form.save()
-        
+
         # Link the task back to the ticket as the web client would
         ticket.task_id = task
         self.assertEqual(
-            ticket.task_id.project_id, 
+            ticket.task_id.project_id,
             ticket.project_id,
-            "Backend explicitly assigns the ticket's project_id to the task when linked."
+            "Backend explicitly assigns the ticket's project_id to the task "
+            "when linked.",
         )

--- a/helpdesk_mgmt_project/tests/test_helpdesk_ticket.py
+++ b/helpdesk_mgmt_project/tests/test_helpdesk_ticket.py
@@ -1,4 +1,3 @@
-from odoo.tests import Form
 from odoo.tools.safe_eval import safe_eval
 
 from odoo.addons.helpdesk_mgmt.tests.common import TestHelpdeskTicketBase
@@ -180,16 +179,20 @@ class TestHelpdeskTicketProject(TestHelpdeskTicketBase):
     def test_create_task_from_ticket(self):
         """Test creating a task from the ticket simulating UI context/RPC."""
 
-        ticket_form = Form(self.env["helpdesk.ticket"])
-        ticket_form.name = "Test Ticket for Task Creation"
-        ticket_form.project_id = self.project1
-        ticket_form.description = "Testing Description"
-        ticket = ticket_form.save()
+        ticket = self.env["helpdesk.ticket"].create(
+            {
+                "name": "Test Ticket for Task Creation",
+                "project_id": self.project1.id,
+                "description": "Testing Description",
+            }
+        )
 
         # Create a task WITHOUT project context to test the backend explicit assignment
-        task_form = Form(self.env["project.task"])
-        task_form.name = "Task generated from ticket"
-        task = task_form.save()
+        task = self.env["project.task"].create(
+            {
+                "name": "Task generated from ticket",
+            }
+        )
 
         # Link the task back to the ticket as the web client would
         ticket.task_id = task

--- a/helpdesk_mgmt_project/tests/test_helpdesk_ticket.py
+++ b/helpdesk_mgmt_project/tests/test_helpdesk_ticket.py
@@ -1,5 +1,5 @@
 from odoo.tools.safe_eval import safe_eval
-
+from odoo.tests import Form
 from odoo.addons.helpdesk_mgmt.tests.common import TestHelpdeskTicketBase
 
 
@@ -175,3 +175,25 @@ class TestHelpdeskTicketProject(TestHelpdeskTicketBase):
         self.assertEqual(2, len(milestone_requests))
         self.assertIn(ticket_1, milestone_requests)
         self.assertIn(ticket_2, milestone_requests)
+
+    def test_create_task_from_ticket(self):
+        """Test creating a task from the ticket simulating UI context/RPC."""
+        
+        ticket_form = Form(self.env["helpdesk.ticket"])
+        ticket_form.name = "Test Ticket for Task Creation"
+        ticket_form.project_id = self.project1
+        ticket_form.description = "Testing Description"
+        ticket = ticket_form.save()
+
+        # Create a task WITHOUT project context to test the backend explicit assignment
+        task_form = Form(self.env["project.task"])
+        task_form.name = "Task generated from ticket"
+        task = task_form.save()
+        
+        # Link the task back to the ticket as the web client would
+        ticket.task_id = task
+        self.assertEqual(
+            ticket.task_id.project_id, 
+            ticket.project_id,
+            "Backend explicitly assigns the ticket's project_id to the task when linked."
+        )

--- a/helpdesk_mgmt_project/tests/test_helpdesk_ticket.py
+++ b/helpdesk_mgmt_project/tests/test_helpdesk_ticket.py
@@ -202,3 +202,26 @@ class TestHelpdeskTicketProject(TestHelpdeskTicketBase):
             "Backend explicitly assigns the ticket's project_id to the task "
             "when linked.",
         )
+
+    def test_create_ticket_with_task_assigns_project(self):
+        """Test creating a ticket with an existing task assigns the project."""
+        task = self.env["project.task"].create(
+            {
+                "name": "Task without project",
+            }
+        )
+
+        self.env["helpdesk.ticket"].create(
+            {
+                "name": "Test Ticket with Task",
+                "project_id": self.project1.id,
+                "task_id": task.id,
+                "description": "Testing Description",
+            }
+        )
+        self.assertEqual(
+            task.project_id,
+            self.project1,
+            "Backend explicitly assigns the ticket's project_id to the task "
+            "when linked during creation.",
+        )

--- a/helpdesk_mgmt_project/views/helpdesk_ticket_view.xml
+++ b/helpdesk_mgmt_project/views/helpdesk_ticket_view.xml
@@ -33,9 +33,7 @@
         <field name="inherit_id" ref="helpdesk_mgmt.ticket_view_form" />
         <field name="arch" type="xml">
             <xpath expr="//field[@name='partner_email']" position="after">
-                <field name="project_id" invisible="1" />
                 <field name="project_id" groups="project.group_project_user" />
-                <field name="task_id" invisible="1" />
                 <field
                     name="task_id"
                     domain="[('project_id', '=', project_id)]"

--- a/helpdesk_mgmt_timesheet/views/helpdesk_ticket_view.xml
+++ b/helpdesk_mgmt_timesheet/views/helpdesk_ticket_view.xml
@@ -264,7 +264,7 @@
                 <field name="allow_timesheet" invisible="1" />
             </xpath>
             <!-- It is important to apply the required attrs to the field which has groups !-->
-            <xpath expr="//field[@name='project_id'][2]" position="attributes">
+            <xpath expr="//field[@name='project_id']" position="attributes">
                 <attribute name="required">allow_timesheet</attribute>
             </xpath>
         </field>


### PR DESCRIPTION
**Problem Description**
When creating a new task from the `task_id` field on a `helpdesk.ticket` form, the task is created as a "Private Task" (assigned to the user's private project) instead of adopting the project already selected on the ticket. 

**Expected Behavior**
Any new task created and linked to a ticket should explicitly inherit the `project_id` from the Helpdesk Ticket.

**Root Cause**
The previous implementation relied solely on the UI passing `default_project_id` via context. However, duplicate `project_id` field definitions in the XML (one hidden, one visible) caused the Odoo 18 Web Client to fail during context evaluation, resulting in the task being created without a project. Furthermore, the backend did not explicitly enforce the project synchronization upon task linkage.

**Solution**
Following OCA guidelines prioritizing Explicit over Implicit behavior:
1. **Backend Fix**: Overrode `create` and `write` on `helpdesk.ticket`. If a task is linked that does not have a `project_id`, it is now explicitly assigned the ticket's `project_id`.
2. **UI Cleanup**: Removed the redundant `invisible="1"` duplicate field definitions in `helpdesk_ticket_view_form` to prevent Web Client evaluation issues.
3. **Tests**: Updated the unit test to deliberately create a task without context and verify that the backend correctly and explicitly assigns the project upon linking it to the ticket.