### PR TITLE
[18.0][IMP] helpdesk_ticket_partner_response: stage change via email and portal

### DIFF
--- a/helpdesk_ticket_partner_response/models/helpdesk_ticket.py
+++ b/helpdesk_ticket_partner_response/models/helpdesk_ticket.py
@@ -9,9 +9,11 @@ class HelpdeskTicket(models.Model):
 
     def _message_post_after_hook(self, message, msg_vals):
         """Change status of ticket if the required conditions are satisfied"""
+        public_user = self.env.ref("base.public_user")
         if (
             self
-            and self.env.user.partner_id.id == self.partner_id.id
+            and self.env.user.partner_id.id
+            in (self.partner_id.id, public_user.partner_id.id)
             and self.team_id.autoupdate_ticket_stage
             and self.stage_id in self.team_id.autopupdate_src_stage_ids
         ):

--- a/helpdesk_ticket_partner_response/models/mail_thread.py
+++ b/helpdesk_ticket_partner_response/models/mail_thread.py
@@ -17,19 +17,35 @@ class MailThread(models.AbstractModel):
             if email_from:
                 email_from = email_normalize(email_from)
 
-            if ticket_id:
-                ticket = self.env["helpdesk.ticket"].sudo().browse(int(ticket_id))
-                if ticket and routes[0][3]:
-                    partner_id = (
+            ticket = self.env["helpdesk.ticket"].sudo().browse(int(ticket_id)).exists()
+            user_id = routes[0][3]
+            if ticket:
+                if not (
+                    ticket.team_id.autoupdate_ticket_stage
+                    and ticket.stage_id in ticket.team_id.autopupdate_src_stage_ids
+                ):
+                    return None
+
+                update_stage = False
+                email_partner = False
+                if ticket.partner_email == email_from:
+                    update_stage = True
+
+                ticket_partner = ticket.partner_id
+                if user_id:
+                    email_partner = (
                         self.env["res.users"]
-                        .search([("id", "=", routes[0][3])], limit=1)
-                        .partner_id.id
+                        .search([("id", "=", user_id)], limit=1)
+                        .partner_id
                     )
-                    partner_matches = partner_id and partner_id == ticket.partner_id.id
-                    partner_email_matches = ticket.partner_id.email == email_from
-                    if (
-                        (partner_matches or partner_email_matches)
-                        and ticket.team_id.autoupdate_ticket_stage
-                        and ticket.stage_id in ticket.team_id.autopupdate_src_stage_ids
-                    ):
-                        ticket.stage_id = ticket.team_id.autopupdate_dest_stage_id.id
+                if email_partner and ticket_partner:
+                    update_stage = email_partner.id == ticket_partner.id
+                elif email_partner:
+                    update_stage = email_partner.email == ticket.partner_email
+                elif ticket_partner:
+                    update_stage = ticket_partner.email == email_from
+
+                if update_stage:
+                    ticket.stage_id = ticket.team_id.autopupdate_dest_stage_id.id
+
+        return None

--- a/helpdesk_ticket_partner_response/models/mail_thread.py
+++ b/helpdesk_ticket_partner_response/models/mail_thread.py
@@ -1,4 +1,5 @@
 from odoo import api, models
+from odoo.tools import email_normalize
 
 
 class MailThread(models.AbstractModel):
@@ -6,12 +7,16 @@ class MailThread(models.AbstractModel):
 
     @api.model
     def _message_route_process(self, message, message_dict, routes):
-        self.change_status_ticket_from_portal(routes)
+        self.change_ticket_status_via_mail(routes, message_dict)
         return super()._message_route_process(message, message_dict, routes)
 
-    def change_status_ticket_from_portal(self, routes):
+    def change_ticket_status_via_mail(self, routes, message_dict):
         if routes and routes[0][0] == "helpdesk.ticket":
             ticket_id = routes[0][1]
+            email_from = message_dict.get("email_from")
+            if email_from:
+                email_from = email_normalize(email_from)
+
             if ticket_id:
                 ticket = self.env["helpdesk.ticket"].sudo().browse(int(ticket_id))
                 if ticket and routes[0][3]:
@@ -20,14 +25,11 @@ class MailThread(models.AbstractModel):
                         .search([("id", "=", routes[0][3])], limit=1)
                         .partner_id.id
                     )
-                    if partner_id:
-                        if (
-                            ticket
-                            and partner_id == ticket.partner_id.id
-                            and ticket.team_id.autoupdate_ticket_stage
-                            and ticket.stage_id
-                            in ticket.team_id.autopupdate_src_stage_ids
-                        ):
-                            ticket.stage_id = (
-                                ticket.team_id.autopupdate_dest_stage_id.id
-                            )
+                    partner_matches = partner_id and partner_id == ticket.partner_id.id
+                    partner_email_matches = ticket.partner_id.email == email_from
+                    if (
+                        (partner_matches or partner_email_matches)
+                        and ticket.team_id.autoupdate_ticket_stage
+                        and ticket.stage_id in ticket.team_id.autopupdate_src_stage_ids
+                    ):
+                        ticket.stage_id = ticket.team_id.autopupdate_dest_stage_id.id


### PR DESCRIPTION
Currently, sending an email or replying as non-logged in user via portal may not trigger stage change. This PR aims to fix this behaviour.