### PR TITLE
[19.0][IMP] helpdesk_mgmt: team-based automatic ticket assignment

### DIFF
--- a/helpdesk_mgmt/README.rst
+++ b/helpdesk_mgmt/README.rst
@@ -103,6 +103,23 @@ Teams
 
 |image4|
 
+Automatic assignment
+~~~~~~~~~~~~~~~~~~~~
+
+Each team has an *Assignment Method* that decides how new unassigned
+tickets get an assigned user:
+
+- *Manually*: no automatic assignment (default).
+- *Random (round-robin)*: rotate cyclically over the team members.
+- *Balanced (least busy)*: assign to the member with the fewest open
+  tickets.
+- *By Tags*: assign to a member mapped to the ticket tags, picking the
+  least busy one. Fill in the *Tag Assignments* tab to map each tag to
+  its eligible members.
+
+Tickets created directly in a folded or closed stage are never
+auto-assigned.
+
 Tags
 ----
 

--- a/helpdesk_mgmt/i18n/helpdesk_mgmt.pot
+++ b/helpdesk_mgmt/i18n/helpdesk_mgmt.pot
@@ -1786,3 +1786,43 @@ msgid ""
 "{{object.company_id.name}} Ticket Assignment (Ref {{object.number or 'n/a' "
 "}})"
 msgstr ""
+
+#. module: helpdesk_mgmt
+#: model:ir.model.fields,field_description:helpdesk_mgmt.field_helpdesk_ticket_team__assign_method
+msgid "Assignment Method"
+msgstr ""
+
+#. module: helpdesk_mgmt
+#: model:ir.model.fields.selection,name:helpdesk_mgmt.selection__helpdesk_ticket_team__assign_method__manual
+msgid "Manually"
+msgstr ""
+
+#. module: helpdesk_mgmt
+#: model:ir.model.fields.selection,name:helpdesk_mgmt.selection__helpdesk_ticket_team__assign_method__randomly
+msgid "Random (round-robin)"
+msgstr ""
+
+#. module: helpdesk_mgmt
+#: model:ir.model.fields.selection,name:helpdesk_mgmt.selection__helpdesk_ticket_team__assign_method__balanced
+msgid "Balanced (least busy)"
+msgstr ""
+
+#. module: helpdesk_mgmt
+#: model:ir.model.fields.selection,name:helpdesk_mgmt.selection__helpdesk_ticket_team__assign_method__tags
+msgid "By Tags"
+msgstr ""
+
+#. module: helpdesk_mgmt
+#: model:ir.model.fields,field_description:helpdesk_mgmt.field_helpdesk_ticket_team__assignment_tag_ids
+msgid "Tag Assignments"
+msgstr ""
+
+#. module: helpdesk_mgmt
+#: model:ir.model,name:helpdesk_mgmt.model_helpdesk_ticket_team_assignment_tag
+msgid "Helpdesk Team Tag Assignment"
+msgstr ""
+
+#. module: helpdesk_mgmt
+#: model:ir.model.fields,field_description:helpdesk_mgmt.field_helpdesk_ticket_team_assignment_tag__user_ids
+msgid "Members eligible to be auto-assigned tickets carrying this tag."
+msgstr ""

--- a/helpdesk_mgmt/models/__init__.py
+++ b/helpdesk_mgmt/models/__init__.py
@@ -4,6 +4,7 @@ from . import helpdesk_ticket_tag
 from . import helpdesk_ticket_channel
 from . import helpdesk_ticket_category
 from . import helpdesk_ticket_team
+from . import helpdesk_ticket_team_assignment_tag
 from . import ir_http
 from . import res_company
 from . import res_config_settings

--- a/helpdesk_mgmt/models/helpdesk_ticket.py
+++ b/helpdesk_mgmt/models/helpdesk_ticket.py
@@ -257,6 +257,11 @@ class HelpdeskTicket(models.Model):
                     # and notifications can be sent by email
                     # if a mail template is configured
                     vals["stage_id"] = team._get_applicable_stages()[:1].id
+                if team.assign_method != "manual" and "user_id" not in vals:
+                    # The team drives the assignment, so prevent the company
+                    # "assign to creator" default from claiming the ticket and
+                    # let _helpdesk_auto_assign pick the member afterwards.
+                    vals["user_id"] = False
             # Automatically set default e-mail channel when created from the
             # fetchmail cron task
             if self.env.context.get("fetchmail_cron_running") and not vals.get(
@@ -268,7 +273,23 @@ class HelpdeskTicket(models.Model):
                 )
                 if channel_email_id:
                     vals["channel_id"] = channel_email_id.id
-        return super().create(vals_list)
+        tickets = super().create(vals_list)
+        tickets._helpdesk_auto_assign()
+        return tickets
+
+    def _helpdesk_auto_assign(self):
+        """Assign a team member to unassigned tickets according to the
+        team's ``assign_method``. Skips already assigned tickets, tickets
+        without a team and tickets created directly in a folded/closed stage.
+        """
+        for ticket in self:
+            if ticket.user_id or not ticket.team_id:
+                continue
+            if ticket.stage_id.fold or ticket.stage_id.closed:
+                continue
+            user = ticket.team_id._get_auto_assign_user(tag_ids=ticket.tag_ids.ids)
+            if user:
+                ticket.user_id = user.id
 
     def copy(self, default=None):
         self.ensure_one()

--- a/helpdesk_mgmt/models/helpdesk_ticket_team.py
+++ b/helpdesk_mgmt/models/helpdesk_ticket_team.py
@@ -71,6 +71,31 @@ class HelpdeskTeam(models.Model):
     parent_id = fields.Many2one(
         "helpdesk.ticket.team", string="Parent Team", index=True
     )
+    assign_method = fields.Selection(
+        selection=[
+            ("manual", "Manually"),
+            ("randomly", "Random (round-robin)"),
+            ("balanced", "Balanced (least busy)"),
+            ("tags", "By Tags"),
+        ],
+        string="Assignment Method",
+        default="manual",
+        required=True,
+        tracking=True,
+        help="How new unassigned tickets of this team get an assigned user:\n"
+        "- Manually: no automatic assignment.\n"
+        "- Random: rotate cyclically over the team members.\n"
+        "- Balanced: assign to the member with the fewest open tickets.\n"
+        "- By Tags: assign to a member mapped to the ticket tags, "
+        "picking the least busy one.",
+    )
+    assignment_tag_ids = fields.One2many(
+        comodel_name="helpdesk.ticket.team.assignment.tag",
+        inverse_name="team_id",
+        string="Tag Assignments",
+        help="Mapping between ticket tags and the members eligible to be "
+        "auto-assigned when the 'By Tags' method is used.",
+    )
     complete_name = fields.Char(
         compute="_compute_complete_name",
         recursive=True,
@@ -140,6 +165,75 @@ class HelpdeskTeam(models.Model):
             team.todo_ticket_count_high_priority = sum(
                 r[4] for r in result if r[0] == team.id and r[3] == "3"
             )
+
+    # ---------------------------------------------------
+    # Auto-assignment
+    # ---------------------------------------------------
+
+    def _get_auto_assign_user(self, tag_ids=None):
+        """Return the member that should take a new ticket of this team.
+
+        The selection depends on ``assign_method``. Returns an empty
+        ``res.users`` recordset when no member can be picked (manual method,
+        team without members, or no tag mapping match).
+        """
+        self.ensure_one()
+        members = self.user_ids
+        if not members or self.assign_method == "manual":
+            return self.env["res.users"]
+        if self.assign_method == "randomly":
+            return self._auto_assign_randomly(members)
+        if self.assign_method == "balanced":
+            return self._auto_assign_balanced(members)
+        if self.assign_method == "tags":
+            return self._auto_assign_by_tags(members, tag_ids or [])
+        return self.env["res.users"]
+
+    def _auto_assign_randomly(self, members):
+        """Round-robin: pick the member right after the last assigned one."""
+        members = members.sorted("id")
+        last_ticket = self.env["helpdesk.ticket"].search(
+            [
+                ("team_id", "=", self.id),
+                ("user_id", "in", members.ids),
+            ],
+            order="assigned_date desc, id desc",
+            limit=1,
+        )
+        if not last_ticket:
+            return members[0]
+        member_ids = members.ids
+        next_index = (member_ids.index(last_ticket.user_id.id) + 1) % len(member_ids)
+        return members[next_index]
+
+    def _auto_assign_balanced(self, members):
+        """Balanced: pick the member with the fewest open tickets."""
+        counts = dict.fromkeys(members.ids, 0)
+        grouped_rows = self.env["helpdesk.ticket"]._read_group(
+            domain=[
+                ("team_id", "=", self.id),
+                ("user_id", "in", members.ids),
+                ("closed", "=", False),
+            ],
+            groupby=["user_id"],
+            aggregates=["__count"],
+        )
+        for user, count in grouped_rows:
+            counts[user.id] = count
+        # Tie-break by member id to keep the choice deterministic.
+        best_id = min(members.ids, key=lambda uid: (counts[uid], uid))
+        return members.browse(best_id)
+
+    def _auto_assign_by_tags(self, members, tag_ids):
+        """By tags: restrict to members mapped to the ticket tags, then
+        fall back to the balanced strategy among that pool."""
+        if not tag_ids:
+            return self.env["res.users"]
+        mappings = self.assignment_tag_ids.filtered(lambda m: m.tag_id.id in tag_ids)
+        candidates = mappings.user_ids & members
+        if not candidates:
+            return self.env["res.users"]
+        return self._auto_assign_balanced(candidates)
 
     def _alias_get_creation_values(self):
         values = super()._alias_get_creation_values()

--- a/helpdesk_mgmt/models/helpdesk_ticket_team_assignment_tag.py
+++ b/helpdesk_mgmt/models/helpdesk_ticket_team_assignment_tag.py
@@ -1,0 +1,29 @@
+from odoo import fields, models
+
+
+class HelpdeskTicketTeamAssignmentTag(models.Model):
+    _name = "helpdesk.ticket.team.assignment.tag"
+    _description = "Helpdesk Team Tag Assignment"
+
+    team_id = fields.Many2one(
+        comodel_name="helpdesk.ticket.team",
+        string="Team",
+        required=True,
+        ondelete="cascade",
+    )
+    tag_id = fields.Many2one(
+        comodel_name="helpdesk.ticket.tag",
+        string="Tag",
+        required=True,
+        ondelete="cascade",
+    )
+    user_ids = fields.Many2many(
+        comodel_name="res.users",
+        string="Members",
+        help="Members eligible to be auto-assigned tickets carrying this tag.",
+    )
+
+    _team_tag_uniq = models.Constraint(
+        "unique(team_id, tag_id)",
+        "A tag can only be mapped once per team.",
+    )

--- a/helpdesk_mgmt/readme/CONFIGURE.md
+++ b/helpdesk_mgmt/readme/CONFIGURE.md
@@ -56,6 +56,22 @@ in the list view.
 
 ![](../static/description/Teams.PNG)
 
+### Automatic assignment
+
+Each team has an *Assignment Method* that decides how new unassigned
+tickets get an assigned user:
+
+-   *Manually*: no automatic assignment (default).
+-   *Random (round-robin)*: rotate cyclically over the team members.
+-   *Balanced (least busy)*: assign to the member with the fewest open
+    tickets.
+-   *By Tags*: assign to a member mapped to the ticket tags, picking the
+    least busy one. Fill in the *Tag Assignments* tab to map each tag to
+    its eligible members.
+
+Tickets created directly in a folded or closed stage are never
+auto-assigned.
+
 ## Tags
 
 1.  Go to *Helpdesk \> Configuration \> Ticket Tags* to edit or create

--- a/helpdesk_mgmt/security/ir.model.access.csv
+++ b/helpdesk_mgmt/security/ir.model.access.csv
@@ -20,3 +20,5 @@ access_helpdesk_ticket_category_user,helpdesk.ticket.category.user,model_helpdes
 access_helpdesk_ticket_category_portal,helpdesk.ticket.category.portal,model_helpdesk_ticket_category,base.group_portal,1,0,0,0
 access_helpdesk_ticket_category_public,helpdesk.ticket.category.public,model_helpdesk_ticket_category,base.group_public,1,0,0,0
 access_helpdesk_ticket_duplicate_wizard,helpdesk.ticket.duplicate.wizard,model_helpdesk_ticket_duplicate_wizard,group_helpdesk_user,1,1,1,1
+access_helpdesk_ticket_team_assignment_tag_manager,helpdesk.ticket.team.assignment.tag.manager,model_helpdesk_ticket_team_assignment_tag,group_helpdesk_manager,1,1,1,1
+access_helpdesk_ticket_team_assignment_tag_user,helpdesk.ticket.team.assignment.tag.user,model_helpdesk_ticket_team_assignment_tag,base.group_user,1,0,0,0

--- a/helpdesk_mgmt/static/description/index.html
+++ b/helpdesk_mgmt/static/description/index.html
@@ -383,18 +383,21 @@ ul.auto-toc {
 <li><a class="reference internal" href="#channels" id="toc-entry-2">Channels</a></li>
 <li><a class="reference internal" href="#categories" id="toc-entry-3">Categories</a></li>
 <li><a class="reference internal" href="#stages" id="toc-entry-4">Stages</a></li>
-<li><a class="reference internal" href="#teams" id="toc-entry-5">Teams</a></li>
-<li><a class="reference internal" href="#tags" id="toc-entry-6">Tags</a></li>
-<li><a class="reference internal" href="#permissions" id="toc-entry-7">Permissions</a></li>
+<li><a class="reference internal" href="#teams" id="toc-entry-5">Teams</a><ul>
+<li><a class="reference internal" href="#automatic-assignment" id="toc-entry-6">Automatic assignment</a></li>
 </ul>
 </li>
-<li><a class="reference internal" href="#usage" id="toc-entry-8">Usage</a></li>
-<li><a class="reference internal" href="#known-issues-roadmap" id="toc-entry-9">Known issues / Roadmap</a></li>
-<li><a class="reference internal" href="#bug-tracker" id="toc-entry-10">Bug Tracker</a></li>
-<li><a class="reference internal" href="#credits" id="toc-entry-11">Credits</a><ul>
-<li><a class="reference internal" href="#authors" id="toc-entry-12">Authors</a></li>
-<li><a class="reference internal" href="#contributors" id="toc-entry-13">Contributors</a></li>
-<li><a class="reference internal" href="#maintainers" id="toc-entry-14">Maintainers</a></li>
+<li><a class="reference internal" href="#tags" id="toc-entry-7">Tags</a></li>
+<li><a class="reference internal" href="#permissions" id="toc-entry-8">Permissions</a></li>
+</ul>
+</li>
+<li><a class="reference internal" href="#usage" id="toc-entry-9">Usage</a></li>
+<li><a class="reference internal" href="#known-issues-roadmap" id="toc-entry-10">Known issues / Roadmap</a></li>
+<li><a class="reference internal" href="#bug-tracker" id="toc-entry-11">Bug Tracker</a></li>
+<li><a class="reference internal" href="#credits" id="toc-entry-12">Credits</a><ul>
+<li><a class="reference internal" href="#authors" id="toc-entry-13">Authors</a></li>
+<li><a class="reference internal" href="#contributors" id="toc-entry-14">Contributors</a></li>
+<li><a class="reference internal" href="#maintainers" id="toc-entry-15">Maintainers</a></li>
 </ul>
 </li>
 </ul>
@@ -460,9 +463,25 @@ in the list view.</p>
 <li>You can also Activate or Deactivate teams.</li>
 </ol>
 <p><img alt="image4" src="https://raw.githubusercontent.com/OCA/helpdesk/19.0/helpdesk_mgmt/static/description/Teams.PNG" /></p>
+<div class="section" id="automatic-assignment">
+<h4><a class="toc-backref" href="#toc-entry-6">Automatic assignment</a></h4>
+<p>Each team has an <em>Assignment Method</em> that decides how new unassigned
+tickets get an assigned user:</p>
+<ul class="simple">
+<li><em>Manually</em>: no automatic assignment (default).</li>
+<li><em>Random (round-robin)</em>: rotate cyclically over the team members.</li>
+<li><em>Balanced (least busy)</em>: assign to the member with the fewest open
+tickets.</li>
+<li><em>By Tags</em>: assign to a member mapped to the ticket tags, picking the
+least busy one. Fill in the <em>Tag Assignments</em> tab to map each tag to
+its eligible members.</li>
+</ul>
+<p>Tickets created directly in a folded or closed stage are never
+auto-assigned.</p>
+</div>
 </div>
 <div class="section" id="tags">
-<h3><a class="toc-backref" href="#toc-entry-6">Tags</a></h3>
+<h3><a class="toc-backref" href="#toc-entry-7">Tags</a></h3>
 <ol class="arabic simple">
 <li>Go to <em>Helpdesk &gt; Configuration &gt; Ticket Tags</em> to edit or create new
 tags.</li>
@@ -474,7 +493,7 @@ tags.</li>
 <p><img alt="image5" src="https://raw.githubusercontent.com/OCA/helpdesk/19.0/helpdesk_mgmt/static/description/Tags.PNG" /></p>
 </div>
 <div class="section" id="permissions">
-<h3><a class="toc-backref" href="#toc-entry-7">Permissions</a></h3>
+<h3><a class="toc-backref" href="#toc-entry-8">Permissions</a></h3>
 <p>There are restrictions to read tickets according to the user’s
 permissions set in Helpdesk.</p>
 <ol class="arabic simple">
@@ -489,7 +508,7 @@ not assigned to any team nor user.</li>
 </div>
 </div>
 <div class="section" id="usage">
-<h2><a class="toc-backref" href="#toc-entry-8">Usage</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-9">Usage</a></h2>
 <ol class="arabic simple">
 <li>Go to <em>Helpdesk</em> or <em>Helpdesk &gt; Dashboard</em> to see the tickets
 dashboard</li>
@@ -513,7 +532,7 @@ column of a stage.</li>
 <p><img alt="Tickets01" src="https://raw.githubusercontent.com/OCA/helpdesk/19.0/helpdesk_mgmt/static/description/Tickets01.PNG" /> <img alt="Tickets02" src="https://raw.githubusercontent.com/OCA/helpdesk/19.0/helpdesk_mgmt/static/description/Tickets02.PNG" /></p>
 </div>
 <div class="section" id="known-issues-roadmap">
-<h2><a class="toc-backref" href="#toc-entry-9">Known issues / Roadmap</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-10">Known issues / Roadmap</a></h2>
 <ul class="simple">
 <li>Add a tour feature similar to what the <tt class="docutils literal">project</tt> module defines to
 discover projects / tasks.</li>
@@ -523,7 +542,7 @@ portal users.</li>
 </ul>
 </div>
 <div class="section" id="bug-tracker">
-<h2><a class="toc-backref" href="#toc-entry-10">Bug Tracker</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-11">Bug Tracker</a></h2>
 <p>Bugs are tracked on <a class="reference external" href="https://github.com/OCA/helpdesk/issues">GitHub Issues</a>.
 In case of trouble, please check there if your issue has already been reported.
 If you spotted it first, help us to smash it by providing a detailed and welcomed
@@ -531,9 +550,9 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <p>Do not contact contributors directly about support or help with technical issues.</p>
 </div>
 <div class="section" id="credits">
-<h2><a class="toc-backref" href="#toc-entry-11">Credits</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-12">Credits</a></h2>
 <div class="section" id="authors">
-<h3><a class="toc-backref" href="#toc-entry-12">Authors</a></h3>
+<h3><a class="toc-backref" href="#toc-entry-13">Authors</a></h3>
 <ul class="simple">
 <li>AdaptiveCity</li>
 <li>Tecnativa</li>
@@ -545,7 +564,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 </ul>
 </div>
 <div class="section" id="contributors">
-<h3><a class="toc-backref" href="#toc-entry-13">Contributors</a></h3>
+<h3><a class="toc-backref" href="#toc-entry-14">Contributors</a></h3>
 <ul class="simple">
 <li><a class="reference external" href="https://www.domatix.com">Domatix</a>:<ul>
 <li>Carlos Martínez</li>
@@ -605,7 +624,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 </ul>
 </div>
 <div class="section" id="maintainers">
-<h3><a class="toc-backref" href="#toc-entry-14">Maintainers</a></h3>
+<h3><a class="toc-backref" href="#toc-entry-15">Maintainers</a></h3>
 <p>This module is maintained by the OCA.</p>
 <a class="reference external image-reference" href="https://odoo-community.org">
 <img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />

--- a/helpdesk_mgmt/tests/__init__.py
+++ b/helpdesk_mgmt/tests/__init__.py
@@ -1,5 +1,6 @@
 from . import test_helpdesk_ticket
 from . import test_helpdesk_ticket_team
+from . import test_helpdesk_ticket_auto_assign
 from . import test_helpdesk_portal
 from . import test_helpdesk_fetchmail
 from . import test_res_partner

--- a/helpdesk_mgmt/tests/test_helpdesk_ticket_auto_assign.py
+++ b/helpdesk_mgmt/tests/test_helpdesk_ticket_auto_assign.py
@@ -1,0 +1,87 @@
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+from odoo.tests import new_test_user
+
+from odoo.addons.base.tests.common import BaseCommon
+
+
+class TestHelpdeskAutoAssign(BaseCommon):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.Ticket = cls.env["helpdesk.ticket"]
+        cls.Team = cls.env["helpdesk.ticket.team"]
+        # Isolate the team assignment method from the company-level
+        # "assign to creator" default.
+        cls.env.company.helpdesk_mgmt_ticket_auto_assign = False
+        cls.user_a = new_test_user(cls.env, login="hd-assign-a")
+        cls.user_b = new_test_user(cls.env, login="hd-assign-b")
+        cls.tag_lang = cls.env["helpdesk.ticket.tag"].create({"name": "Spanish"})
+        cls.tag_other = cls.env["helpdesk.ticket.tag"].create({"name": "Hardware"})
+        cls.stage_closed = cls.env.ref("helpdesk_mgmt.helpdesk_ticket_stage_done")
+
+    def _new_team(self, method, members):
+        return self.Team.create(
+            {
+                "name": f"Auto Team {method}",
+                "assign_method": method,
+                "user_ids": [(6, 0, members.ids)],
+            }
+        )
+
+    def _new_ticket(self, team, **vals):
+        values = {
+            "name": "Auto ticket",
+            "description": "x",
+            "team_id": team.id,
+        }
+        values.update(vals)
+        return self.Ticket.create(values)
+
+    def test_manual_no_assignment(self):
+        team = self._new_team("manual", self.user_a + self.user_b)
+        ticket = self._new_ticket(team)
+        self.assertFalse(ticket.user_id)
+
+    def test_randomly_round_robin(self):
+        members = self.user_a + self.user_b
+        team = self._new_team("randomly", members)
+        ordered = members.sorted("id")
+        t1 = self._new_ticket(team)
+        t2 = self._new_ticket(team)
+        t3 = self._new_ticket(team)
+        self.assertEqual(t1.user_id, ordered[0])
+        self.assertEqual(t2.user_id, ordered[1])
+        self.assertEqual(t3.user_id, ordered[0])
+
+    def test_balanced_least_busy(self):
+        team = self._new_team("balanced", self.user_a + self.user_b)
+        # Seed an open ticket already assigned to user_a.
+        self._new_ticket(team, user_id=self.user_a.id)
+        # The next unassigned ticket must go to the idle member.
+        ticket = self._new_ticket(team)
+        self.assertEqual(ticket.user_id, self.user_b)
+
+    def test_tags_within_pool(self):
+        team = self._new_team("tags", self.user_a + self.user_b)
+        self.env["helpdesk.ticket.team.assignment.tag"].create(
+            {
+                "team_id": team.id,
+                "tag_id": self.tag_lang.id,
+                "user_ids": [(6, 0, self.user_a.ids)],
+            }
+        )
+        mapped = self._new_ticket(team, tag_ids=[(6, 0, self.tag_lang.ids)])
+        self.assertEqual(mapped.user_id, self.user_a)
+        # A tag without mapping leaves the ticket unassigned.
+        unmapped = self._new_ticket(team, tag_ids=[(6, 0, self.tag_other.ids)])
+        self.assertFalse(unmapped.user_id)
+
+    def test_no_members(self):
+        team = self._new_team("randomly", self.env["res.users"])
+        ticket = self._new_ticket(team)
+        self.assertFalse(ticket.user_id)
+
+    def test_folded_stage_not_assigned(self):
+        team = self._new_team("randomly", self.user_a + self.user_b)
+        ticket = self._new_ticket(team, stage_id=self.stage_closed.id)
+        self.assertFalse(ticket.user_id)

--- a/helpdesk_mgmt/views/helpdesk_ticket_team_views.xml
+++ b/helpdesk_mgmt/views/helpdesk_ticket_team_views.xml
@@ -111,9 +111,27 @@
                             <field name="show_in_portal" />
                             <field name="category_ids" widget="many2many_tags" />
                         </group>
-                        <group name="right" />
+                        <group name="right">
+                            <field name="assign_method" />
+                        </group>
                     </group>
                     <notebook>
+                        <page
+                            name="tag_assignments"
+                            string="Tag Assignments"
+                            invisible="assign_method != 'tags'"
+                        >
+                            <field name="assignment_tag_ids">
+                                <list editable="bottom">
+                                    <field name="tag_id" />
+                                    <field
+                                        name="user_ids"
+                                        widget="many2many_tags"
+                                        domain="[('share', '=', False)]"
+                                    />
+                                </list>
+                            </field>
+                        </page>
                         <page name="members" string="Team Members">
                             <field
                                 name="user_ids"


### PR DESCRIPTION
## What does this PR do?

Adds configurable automatic assignment of new tickets to team members.

A new `assign_method` field on `helpdesk.ticket.team` controls the strategy:

- **Manually** (default): no automatic assignment.
- **Random (round-robin)**: cycles through team members in deterministic order.
- **Balanced (least busy)**: assigns to the member with fewest open tickets.
- **By Tags**: assigns to a member mapped to the ticket's tags (least busy
  among eligible); mapping configured via the new *Tag Assignments* tab on
  the team form.

The new `helpdesk.ticket.team.assignment.tag` model stores the tag→members
mapping. Tickets created in a folded/closed stage are never auto-assigned.
For non-manual teams, the company-level "assign to creator" default is
overridden so the team strategy takes precedence.
