### PR TITLE
[17.0][FIX] helpdesk_ticket_close_inactive: fix autoclose loop for multiple teams

### DIFF
--- a/helpdesk_ticket_close_inactive/models/helpdesk_ticket_team.py
+++ b/helpdesk_ticket_close_inactive/models/helpdesk_ticket_team.py
@@ -79,6 +79,9 @@ class HelpdeskTicketTeam(models.Model):
         else:
             teams = self.search([("close_inactive_tickets", "=", True)])
 
+        warning_email_ids = []
+        closing_email_ids = []
+
         for team_id in teams:
             ticket_stage_ids = team_id.ticket_stage_ids.ids
             ticket_category_ids = team_id.ticket_category_ids.ids
@@ -106,8 +109,7 @@ class HelpdeskTicketTeam(models.Model):
                 search_domain.append(("category_id", "in", ticket_category_ids))
 
             warning_ticket_ids = self.env["helpdesk.ticket"].search(search_domain)
-            warning_email_ids = []
-            closing_email_ids = []
+
             if warning_ticket_ids:
                 for ticket in warning_ticket_ids:
                     # Set template context
@@ -160,7 +162,8 @@ class HelpdeskTicketTeam(models.Model):
                         msg = "Ticket closed automatically because have \
                         reached the inactivity days limit"
                         ticket.message_post(body=msg)
-            return {
-                "warning_email_ids": warning_email_ids,
-                "closing_email_ids": closing_email_ids,
-            }
+
+        return {
+            "warning_email_ids": warning_email_ids,
+            "closing_email_ids": closing_email_ids,
+        }

--- a/helpdesk_ticket_close_inactive/tests/test_ticket_autoclose.py
+++ b/helpdesk_ticket_close_inactive/tests/test_ticket_autoclose.py
@@ -120,3 +120,28 @@ class TestHelpdeskTicketAutoclose(BaseCommon):
             self.stage_closing,
             "Ticket should be moved to the closing stage",
         )
+
+    def test_multiple_teams_processed_by_cron(self):
+        """Test that the cron processes all active teams in a single execution."""
+        self.ticket.write({"last_stage_update": datetime.today() - timedelta(days=15)})
+        self.ticket2.write({"last_stage_update": datetime.today() - timedelta(days=15)})
+        result = self.env["helpdesk.ticket.team"].close_team_inactive_tickets()
+
+        # Assert BOTH tickets were successfully updated to the closing stage
+        self.assertEqual(
+            self.ticket.stage_id,
+            self.stage_closing,
+            "First team ticket should be closed by multi-team cron process.",
+        )
+        self.assertEqual(
+            self.ticket2.stage_id,
+            self.stage_closing,
+            "Second team ticket should be closed by multi-team cron process.",
+        )
+
+        # Assert exactly 2 closing emails were tracked (one per closed ticket)
+        self.assertEqual(
+            len(result.get("closing_email_ids", [])),
+            2,
+            "The cron should have tracked exactly 2 closing email IDs.",
+        )


### PR DESCRIPTION
Moved the return statement outside of the team loop block. Previously, having the return indented inside the loop caused the method to terminate immediately after processing the first team, leaving any subsequent configured teams completely ignored. 

Additionally, added a new test `test_multiple_teams_processed_by_cron` to verify that the batch cron execution processes multiple teams and tracks the exact number of closing emails correctly.

cc https://github.com/APSL 47681

@miquelalzanillas @lbarry-apsl @mpascuall @peluko00 @javierobcn @BernatObrador @cubells @palomagrc93 @shirashi3771 please review
