### PR TITLE
[18.0][FIX] helpdesk_ticket_partner_response: compare to normalized ticket email

### DIFF
--- a/helpdesk_ticket_partner_response/models/mail_thread.py
+++ b/helpdesk_ticket_partner_response/models/mail_thread.py
@@ -28,7 +28,7 @@ class MailThread(models.AbstractModel):
 
                 update_stage = False
                 email_partner = False
-                if ticket.partner_email == email_from:
+                if email_normalize(ticket.partner_email) == email_from:
                     update_stage = True
 
                 ticket_partner = ticket.partner_id


### PR DESCRIPTION
Currently, if we receive response on ticket from customer with "from" address `"test@domain.com"` and ticket email is set as `"TEST_CUSTOMER <test@domain.com>"`, the stage won't get updated automatically. This fix aims to cover such case.