### PR TITLE
[18.0][IMP] helpdesk_mgmt_rating: Remove unused methods and simplify code

### DIFF
--- a/helpdesk_mgmt_rating/models/helpdesk_ticket.py
+++ b/helpdesk_mgmt_rating/models/helpdesk_ticket.py
@@ -51,35 +51,10 @@ class HelpdeskTicket(models.Model):
                         force_send=force_send,
                     )
 
-    def rating_apply(
-        self,
-        rate,
-        token=None,
-        rating=None,
-        feedback=None,
-        subtype_xmlid=None,
-        notify_delay_send=False,
-    ):
-        return super().rating_apply(
-            rate,
-            token=token,
-            rating=rating,
-            feedback=feedback,
-            subtype_xmlid="helpdesk_mgmt_rating.mt_ticket_rating",
-            notify_delay_send=notify_delay_send,
+    def _rating_apply_get_default_subtype_id(self):
+        return self.env["ir.model.data"]._xmlid_to_res_id(
+            "helpdesk_mgmt_rating.mt_ticket_rating"
         )
-
-    def _rating_get_partner(self):
-        res = super()._rating_get_partner()
-        if not res and self.partner_id:
-            return self.partner_id
-        return res
-
-    def rating_get_parent_model_name(self, vals):
-        return "helpdesk.ticket"
-
-    def rating_get_ticket_id(self):
-        return self.id
 
     def action_view_ticket_rating(self):
         self.ensure_one()


### PR DESCRIPTION
Remove unused methods and simplify code

Changes done:
- [x] The `rating_apply()` method has been removed, and `_rating_apply_get_default_subtype_id()` has been added to specify the subtype to be used
- [x] The `_rating_get_partner()` method has been removed; rating now uses `partner_id` by default
- [x] The `rating_get_parent_model_name()` method has been removed because it no longer exists
- [x] The `rating_get_ticket_id()` method has been removed because it is no longer used

@Tecnativa