### PR TITLE
[19.0][IMP+FIX] helpdesk_mgmt: Categories on new ticket portal page

### DIFF
--- a/helpdesk_mgmt/__manifest__.py
+++ b/helpdesk_mgmt/__manifest__.py
@@ -4,7 +4,7 @@
     "name": "Helpdesk Management",
     "summary": """
         Helpdesk""",
-    "version": "19.0.1.0.1",
+    "version": "19.0.1.1.0",
     "license": "AGPL-3",
     "category": "After-Sales",
     "author": "AdaptiveCity, "

--- a/helpdesk_mgmt/controllers/main.py
+++ b/helpdesk_mgmt/controllers/main.py
@@ -44,7 +44,11 @@ class HelpdeskTicketController(http.Controller):
         company = request.env.company
         category_model = http.request.env["helpdesk.ticket.category"]
         domain = [("active", "=", True), ("show_in_portal", "=", True)]
-        return category_model.with_company(company.id).search(domain)
+        return (
+            category_model.with_company(company.id).search(domain)
+            if http.request.env.user.company_id.helpdesk_mgmt_portal_select_category
+            else category_model
+        )
 
     @http.route("/new/ticket", type="http", auth="user", website=True)
     def create_new_ticket(self, **kw):

--- a/helpdesk_mgmt/controllers/main.py
+++ b/helpdesk_mgmt/controllers/main.py
@@ -43,7 +43,8 @@ class HelpdeskTicketController(http.Controller):
     def _get_categories(self, **kw):
         company = request.env.company
         category_model = http.request.env["helpdesk.ticket.category"]
-        return category_model.with_company(company.id).search([("active", "=", True)])
+        domain = [("active", "=", True), ("show_in_portal", "=", True)]
+        return category_model.with_company(company.id).search(domain)
 
     @http.route("/new/ticket", type="http", auth="user", website=True)
     def create_new_ticket(self, **kw):

--- a/helpdesk_mgmt/migrations/19.0.1.1.0/post-migration.py
+++ b/helpdesk_mgmt/migrations/19.0.1.1.0/post-migration.py
@@ -1,0 +1,14 @@
+# Copyright 2026 Tecnativa - Víctor Martínez
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    openupgrade.logged_query(
+        env.cr,
+        """
+        UPDATE res_company
+        SET helpdesk_mgmt_portal_select_category = true
+        WHERE helpdesk_mgmt_portal_category_id_required""",
+    )

--- a/helpdesk_mgmt/models/res_company.py
+++ b/helpdesk_mgmt/models/res_company.py
@@ -14,6 +14,9 @@ class Company(models.Model):
         string="Required Team field in Helpdesk portal",
         default=True,
     )
+    helpdesk_mgmt_portal_select_category = fields.Boolean(
+        string="Select category in Helpdesk portal"
+    )
     helpdesk_mgmt_portal_category_id_required = fields.Boolean(
         string="Required Category field in Helpdesk portal",
         default=True,

--- a/helpdesk_mgmt/models/res_config_settings.py
+++ b/helpdesk_mgmt/models/res_config_settings.py
@@ -14,6 +14,10 @@ class ResConfigSettings(models.TransientModel):
         related="company_id.helpdesk_mgmt_portal_team_id_required",
         readonly=False,
     )
+    helpdesk_mgmt_portal_select_category = fields.Boolean(
+        related="company_id.helpdesk_mgmt_portal_select_category",
+        readonly=False,
+    )
     helpdesk_mgmt_portal_category_id_required = fields.Boolean(
         related="company_id.helpdesk_mgmt_portal_category_id_required",
         readonly=False,

--- a/helpdesk_mgmt/views/helpdesk_ticket_templates.xml
+++ b/helpdesk_mgmt/views/helpdesk_ticket_templates.xml
@@ -465,7 +465,7 @@
                         </select>
                     </div>
                 </div>
-                <div class="form-group mb-3">
+                <div class="form-group mb-3" t-if="categories">
                     <label
                         class="col-md-3 col-sm-4 control-label"
                         for="category"

--- a/helpdesk_mgmt/views/res_config_settings_views.xml
+++ b/helpdesk_mgmt/views/res_config_settings_views.xml
@@ -26,6 +26,15 @@
                                 name="helpdesk_mgmt_portal_new_ticket_fields"
                             >
                                 <div class="mt8">
+                                    <field
+                                        name="helpdesk_mgmt_portal_select_category"
+                                    />
+                                    <label
+                                        for="helpdesk_mgmt_portal_select_category"
+                                        string="Category"
+                                    />
+                                </div>
+                                <div class="mt8">
                                     <field name="helpdesk_mgmt_portal_select_team" />
                                     <label
                                         for="helpdesk_mgmt_portal_select_team"
@@ -44,7 +53,10 @@
                                 class="content-group"
                                 name="helpdesk_mgmt_portal_new_ticket_required_fields"
                             >
-                                <div class="mt8">
+                                <div
+                                    class="mt8"
+                                    invisible="not helpdesk_mgmt_portal_select_category"
+                                >
                                     <field
                                         name="helpdesk_mgmt_portal_category_id_required"
                                     />


### PR DESCRIPTION
FWP from 18.0: https://github.com/OCA/helpdesk/pull/1026 + https://github.com/OCA/helpdesk/pull/1027

Changes done:
- [x] Display the appropriate categories on the portal
- [x] Hide the category on the portal's ticket page if there isn't one
- [x] Add select category in Helpdesk portal option

Please @pedrobaeza and @pilarvargas-tecnativa can you review it?

@Tecnativa TT62933