### PR TITLE
[19.0][FIX] helpdesk_mgmt: Set users to Helpdesk Manager group

### DIFF
--- a/helpdesk_mgmt/security/helpdesk_security.xml
+++ b/helpdesk_mgmt/security/helpdesk_security.xml
@@ -28,6 +28,10 @@
             <field name="name">Helpdesk Manager</field>
             <field name="privilege_id" ref="group_helpdesk_privilege" />
             <field name="implied_ids" eval="[(4, ref('group_helpdesk_user'))]" />
+            <field
+                name="user_ids"
+                eval="[(4, ref('base.user_root')), (4, ref('base.user_admin'))]"
+            />
         </record>
     </data>
     <data noupdate="1">


### PR DESCRIPTION
Set users to Helpdesk Manager group

Related to https://github.com/OCA/helpdesk/commit/1118a2cdea37f407773efdb43b1de88d86458d01#diff-c476e8a1ee359deba39215644de59583a36e755a4c9441904c25916eab2f7409L23

Please @pedrobaeza and @pilarvargas-tecnativa can you review it?

@Tecnativa