### PR TITLE
Add WhatsApp gateway integration to helpdesk_mgmt

### DIFF
--- a/helpdesk_mgmt/__manifest__.py
+++ b/helpdesk_mgmt/__manifest__.py
@@ -16,7 +16,7 @@
     "SDi Soluciones, "
     "Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/helpdesk",
-    "depends": ["mail", "portal"],
+    "depends": ["mail", "portal", "mail_gateway_whatsapp"],
     "data": [
         "data/helpdesk_data.xml",
         "security/helpdesk_security.xml",

--- a/helpdesk_mgmt/models/__init__.py
+++ b/helpdesk_mgmt/models/__init__.py
@@ -9,3 +9,4 @@ from . import res_company
 from . import res_config_settings
 from . import res_partner
 from . import res_users
+from . import whatsapp_gateway

--- a/helpdesk_mgmt/models/helpdesk_ticket.py
+++ b/helpdesk_mgmt/models/helpdesk_ticket.py
@@ -94,6 +94,10 @@ class HelpdeskTicket(models.Model):
     )
     partner_name = fields.Char()
     partner_email = fields.Char(string="Email")
+    partner_phone = fields.Char(related="partner_id.phone", string="Phone", readonly=False)
+    whatsapp_channel_id = fields.Many2one(
+        "discuss.channel", string="WhatsApp Channel", copy=False
+    )
     last_stage_update = fields.Datetime(default=fields.Datetime.now)
     assigned_date = fields.Datetime(copy=False)
     closed_date = fields.Datetime(copy=False)
@@ -391,6 +395,9 @@ class HelpdeskTicket(models.Model):
             # imply modifying followers
             return recipients
         return recipients
+
+    def _whatsapp_get_partner(self):
+        return self.partner_id
 
     def _notify_get_reply_to(self, default=None):
         """Override to set alias of tasks to their team if any."""

--- a/helpdesk_mgmt/models/whatsapp_gateway.py
+++ b/helpdesk_mgmt/models/whatsapp_gateway.py
@@ -1,0 +1,72 @@
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from odoo import models
+
+
+class MailGatewayWhatsapp(models.AbstractModel):
+    _inherit = "mail.gateway.whatsapp"
+
+    def _post_process_message(self, message, channel):
+        super()._post_process_message(message, channel)
+        ticket = self._get_or_create_helpdesk_ticket(channel)
+        if not ticket or not (message.body or message.attachment_ids):
+            return
+        ticket_msg = ticket.with_context(
+            link_gateway_message=True
+        ).message_post(
+            body=message.body or "",
+            author_id=message.author_id.id if message.author_id else False,
+            gateway_type="whatsapp",
+            date=message.date,
+            subtype_xmlid="mail.mt_comment",
+            message_type="comment",
+            attachment_ids=message.attachment_ids.ids,
+        )
+        message.gateway_message_id = ticket_msg
+
+    def _get_or_create_helpdesk_ticket(self, channel):
+        # Already linked to a ticket?
+        ticket = self.env["helpdesk.ticket"].search(
+            [("whatsapp_channel_id", "=", channel.id)], limit=1
+        )
+        if ticket:
+            return ticket
+
+        # Identify the customer partner from channel members
+        partner = channel.channel_member_ids.partner_id.filtered(
+            lambda p: not p.user_ids or all(u.share for u in p.user_ids)
+        )[:1]
+        if not partner:
+            partner = channel.channel_member_ids.partner_id[:1]
+
+        # Reuse the most recent open ticket for this partner (without a WA channel)
+        if partner:
+            ticket = self.env["helpdesk.ticket"].search(
+                [
+                    ("partner_id", "=", partner.id),
+                    ("closed", "=", False),
+                    ("whatsapp_channel_id", "=", False),
+                ],
+                order="create_date desc",
+                limit=1,
+            )
+
+        if not ticket:
+            team = self.env["helpdesk.ticket.team"].search([], limit=1)
+            vals = {
+                "name": f"WhatsApp: {channel.name or 'Unknown'}",
+                "description": "<p>Ticket created from incoming WhatsApp message.</p>",
+            }
+            if partner:
+                vals.update(
+                    {
+                        "partner_id": partner.id,
+                        "partner_name": partner.name,
+                        "partner_email": partner.email or "",
+                    }
+                )
+            if team:
+                vals["team_id"] = team.id
+            ticket = self.env["helpdesk.ticket"].sudo().create(vals)
+
+        ticket.sudo().whatsapp_channel_id = channel.id
+        return ticket

--- a/helpdesk_mgmt/views/helpdesk_ticket_views.xml
+++ b/helpdesk_mgmt/views/helpdesk_ticket_views.xml
@@ -44,6 +44,7 @@
                 <field name="category_id" />
                 <field name="tag_ids" />
                 <field name="stage_id" />
+                <field name="company_id" string="Company" />
                 <field name="description" />
                 <filter
                     string="Unassigned"
@@ -150,6 +151,12 @@
                         domain="[]"
                         context="{'group_by':'tag_ids'}"
                     />
+                    <filter
+                        string="Company"
+                        name="group_company"
+                        domain="[]"
+                        context="{'group_by':'company_id'}"
+                    />
                 </group>
             </search>
         </field>
@@ -205,6 +212,19 @@
                                 widget="statinfo"
                             />
                         </button>
+                        <button
+                            class="oe_stat_button"
+                            type="action"
+                            name="%(mail_gateway_whatsapp.whatsapp_composer_act_window)s"
+                            icon="fa-whatsapp"
+                            string="Send WhatsApp"
+                            invisible="not partner_phone"
+                            context="{
+                                'default_res_model': 'helpdesk.ticket',
+                                'default_res_id': id,
+                                'default_number_field_name': 'partner_phone'
+                            }"
+                        />
                     </div>
                     <div class="oe_title">
                         <div
@@ -252,6 +272,9 @@
                             />
                             <field name="partner_name" />
                             <field name="partner_email" />
+                            <field name="partner_phone" widget="phone"/>
+                            <field name="whatsapp_channel_id" readonly="1" optional="show"
+                                invisible="not whatsapp_channel_id"/>
                             <field name="category_id" />
                             <field
                                 name="tag_ids"
@@ -290,6 +313,7 @@
                 <field name="partner_id" optional="hide" widget="many2one_avatar" />
                 <field name="partner_name" optional="show" />
                 <field name="user_id" optional="show" widget="many2one_avatar_user" />
+                <field name="company_id" optional="show" />
                 <field name="category_id" optional="hide" />
                 <field name="unattended" column_invisible="1" />
                 <field name="closed" column_invisible="1" />

--- a/helpdesk_mgmt/wizards/__init__.py
+++ b/helpdesk_mgmt/wizards/__init__.py
@@ -1,1 +1,2 @@
 from . import helpdesk_ticket_duplicate_wizard
+from . import whatsapp_composer

--- a/helpdesk_mgmt/wizards/whatsapp_composer.py
+++ b/helpdesk_mgmt/wizards/whatsapp_composer.py
@@ -1,0 +1,22 @@
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from odoo import models
+
+
+class WhatsappComposer(models.TransientModel):
+    _inherit = "whatsapp.composer"
+
+    def _action_send_whatsapp(self):
+        super()._action_send_whatsapp()
+        if self.res_model != "helpdesk.ticket" or not self.res_id:
+            return
+        ticket = self.env["helpdesk.ticket"].browse(self.res_id)
+        # Mirror sent message into ticket chatter
+        ticket.with_context(link_gateway_message=True).message_post(
+            body=self.body or "",
+            subtype_xmlid="mail.mt_comment",
+            message_type="comment",
+        )
+        # Link channel to ticket so incoming replies route here
+        channel = ticket._whatsapp_get_channel(self.number_field_name, self.gateway_id)
+        if channel and not ticket.whatsapp_channel_id:
+            ticket.whatsapp_channel_id = channel.id


### PR DESCRIPTION
- partner_phone (related) and whatsapp_channel_id fields on helpdesk.ticket
- whatsapp_gateway.py: auto-creates ticket on incoming WhatsApp, mirrors messages to ticket chatter via _post_process_message hook
- whatsapp_composer.py: logs outgoing WhatsApp messages to ticket chatter and links the discuss.channel to the ticket
- Send WhatsApp stat button on ticket form (visible when partner has phone)
- Depends on mail_gateway_whatsapp (OCA/social)