### PR TITLE
[17.0][FIX] helpdesk_mgmt_assign_method: use random selection for assign method

### DIFF
--- a/helpdesk_mgmt_assign_method/__manifest__.py
+++ b/helpdesk_mgmt_assign_method/__manifest__.py
@@ -5,7 +5,7 @@
     "name": "Helpdesk Mgmt Assign Method",
     "summary": """
         Helpdesk Assign Method""",
-    "version": "17.0.1.0.0",
+    "version": "17.0.1.0.1",
     "license": "AGPL-3",
     "author": "Escodoo,Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/helpdesk",

--- a/helpdesk_mgmt_assign_method/models/helpdesk_ticket_team.py
+++ b/helpdesk_mgmt_assign_method/models/helpdesk_ticket_team.py
@@ -3,6 +3,7 @@
 
 
 import logging
+import random
 
 from odoo import _, api, fields, models
 from odoo.exceptions import ValidationError
@@ -66,20 +67,8 @@ class HelpdeskTicketTeam(models.Model):
         return self.env["res.users"]
 
     def _assign_randomly(self, user_ids):
-        """Assign ticket to next user in list after previous assignment."""
-        previous_ticket = self.env["helpdesk.ticket"].search(
-            [("team_id", "=", self.id)],
-            order="create_date desc, id desc",
-            limit=1,
-        )
-        previous_user_id = (
-            previous_ticket.user_id.id if previous_ticket.user_id else None
-        )
-        if previous_user_id in user_ids:
-            next_index = (user_ids.index(previous_user_id) + 1) % len(user_ids)
-        else:
-            next_index = 0
-        return self.env["res.users"].browse(user_ids[next_index])
+        """Assign ticket to a random team member."""
+        return self.env["res.users"].browse(random.choice(user_ids))
 
     def _assign_balanced(self, user_ids):
         """Assign ticket to user with least open tickets."""

--- a/helpdesk_mgmt_assign_method/tests/test_helpdesk_ticket_assign.py
+++ b/helpdesk_mgmt_assign_method/tests/test_helpdesk_ticket_assign.py
@@ -1,6 +1,8 @@
 # Copyright 2025 - TODAY, Kaynnan Lemes <kaynnan.lemes@escodoo.com.br>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
+from unittest.mock import patch
+
 from odoo import Command
 from odoo.exceptions import ValidationError
 from odoo.tests.common import TransactionCase
@@ -43,6 +45,17 @@ class TestHelpdeskTicketAssign(TransactionCase):
     def test_get_new_user_randomly(self):
         self.team.assign_method = "randomly"
         self.assertIn(self.team.get_new_user(), self.team.user_ids)
+
+    def test_assign_randomly_uses_random_choice(self):
+        self.team.assign_method = "randomly"
+        with patch(
+            "odoo.addons.helpdesk_mgmt_assign_method.models."
+            "helpdesk_ticket_team.random.choice",
+            return_value=self.user2.id,
+        ) as mock_choice:
+            user = self.team.get_new_user()
+        mock_choice.assert_called_once_with(sorted(self.team.user_ids.ids))
+        self.assertEqual(user, self.user2)
 
     def test_get_new_user_balanced(self):
         self.team.assign_method = "balanced"


### PR DESCRIPTION
The randomly assign method used round-robin logic (same as sequential) instead of picking a random team member.
Uses random.choice and adds a test mocking the random selection.