### PR TITLE
[18.0][IMP] helpdesk_ticket_partner_response to skip auto replies

### DIFF
--- a/helpdesk_ticket_partner_response/__manifest__.py
+++ b/helpdesk_ticket_partner_response/__manifest__.py
@@ -3,7 +3,7 @@
 {
     "name": "Helpdesk Ticket Partner Response",
     "summary": "Change ticket stage when partner response",
-    "version": "18.0.1.1.2",
+    "version": "18.0.1.2.0",
     "category": "Helpdesk",
     "website": "https://github.com/OCA/helpdesk",
     "author": "Antoni Marroig, APSL-Nagarro, Odoo Community Association (OCA)",

--- a/helpdesk_ticket_partner_response/models/mail_thread.py
+++ b/helpdesk_ticket_partner_response/models/mail_thread.py
@@ -7,8 +7,19 @@ class MailThread(models.AbstractModel):
 
     @api.model
     def _message_route_process(self, message, message_dict, routes):
-        self.change_ticket_status_via_mail(routes, message_dict)
+        if not self._skip_ticket_stage_update_from_autoreply(
+            message, message_dict, routes
+        ):
+            self.change_ticket_status_via_mail(routes, message_dict)
         return super()._message_route_process(message, message_dict, routes)
+
+    def _skip_ticket_stage_update_from_autoreply(self, message, message_dict, routes):
+        """Return True to suppress stage updates triggered by auto-reply emails.
+
+        Override in integration modules to implement auto-reply detection.
+        Returns False by default so no update is suppressed.
+        """
+        return False
 
     def change_ticket_status_via_mail(self, routes, message_dict):
         if routes and routes[0][0] == "helpdesk.ticket":

--- a/helpdesk_ticket_partner_response/tests/test_partner_response.py
+++ b/helpdesk_ticket_partner_response/tests/test_partner_response.py
@@ -1,6 +1,8 @@
 # Copyright 2024 Antoni Marroig(APSL-Nagarro)<amarroig@apsl.net>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
+from unittest.mock import patch
+
 from odoo.addons.base.tests.common import HttpCaseWithUserPortal
 
 MAIL_TEMPLATE = """Return-Path: <whatever-2a840@postmaster.twitter.com>
@@ -307,4 +309,24 @@ class TestCustomerResponse(HttpCaseWithUserPortal):
             {"partner_id": False, "partner_email": "external@example.com"}
         )
         self._message_process_from("wrong@example.com")
+
+    def test_skip_autoreply_default_returns_false(self):
+        """Default hook returns False so normal stage updates are not suppressed."""
+        mail_thread = self.env["mail.thread"]
+        result = mail_thread._skip_ticket_stage_update_from_autoreply(None, {}, [])
+        self.assertFalse(result)
+
+    def test_no_stage_update_when_autoreply_skips(self):
+        """When _skip_ticket_stage_update_from_autoreply returns True (e.g. an
+        integration module detected an auto-reply), the stage must NOT be updated
+        even though the mail would otherwise qualify for an update."""
+        self.ticket = self._create_ticket(self.helpdesk_team1, self.partner_portal)
+        self.ticket.stage_id = self.stage_in_progress
+        MailThreadClass = type(self.env["mail.thread"])
+        with patch.object(
+            MailThreadClass,
+            "_skip_ticket_stage_update_from_autoreply",
+            return_value=True,
+        ):
+            self.message_process()
         self.assertEqual(self.ticket.stage_id, self.stage_in_progress)


### PR DESCRIPTION
Together with #1051 this avoids updating the ticket stage when receiving an automatic email.