### PR TITLE
[18.0][FIX] helpdesk_mgmt: do not reset stage_id when user_id changes within the same team

### DIFF
--- a/helpdesk_mgmt/models/helpdesk_ticket.py
+++ b/helpdesk_mgmt/models/helpdesk_ticket.py
@@ -19,8 +19,13 @@ class HelpdeskTicket(models.Model):
 
     @api.depends("team_id")
     def _compute_stage_id(self):
+        # This compute is executed on user change, even if not changing team, so let's
+        # apply a preventive check for not changing stage if the current one is still
+        # applicable to the current team
         for ticket in self:
-            ticket.stage_id = ticket.team_id._get_applicable_stages()[:1]
+            applicable_stages = ticket.team_id._get_applicable_stages()
+            if ticket.stage_id not in applicable_stages:
+                ticket.stage_id = applicable_stages[:1]
 
     @api.depends("team_id")
     def _compute_user_id(self):

--- a/helpdesk_mgmt/tests/test_helpdesk_ticket.py
+++ b/helpdesk_mgmt/tests/test_helpdesk_ticket.py
@@ -188,16 +188,7 @@ class TestHelpdeskTicket(TestHelpdeskTicketBase):
         """The ticket should take the current user
         and the first team assigned to that user
         """
-        new_ticket = (
-            self.env["helpdesk.ticket"]
-            .with_user(self.user_own)
-            .create(
-                {
-                    "name": "New Ticket",
-                    "description": "Description",
-                }
-            )
-        )
+        new_ticket = self._create_ticket(self.team_a, user=self.user_own)
         self.assertEqual(new_ticket.user_id, self.user_own)
         self.assertEqual(new_ticket.team_id, self.team_a)
         # Change the user to another one with the same team
@@ -251,3 +242,13 @@ class TestHelpdeskTicket(TestHelpdeskTicketBase):
         wizard_rec.action_confirm()
         self.assertEqual(self.ticket.duplicate_id, self.ticket_b_unassigned)
         self.assertIn(self.ticket_b_unassigned.duplicate_ids, self.ticket)
+
+    def test_ticket_change_user_no_stage_reset(self):
+        in_progress_stage = self.env.ref(
+            "helpdesk_mgmt.helpdesk_ticket_stage_in_progress"
+        )
+        new_ticket = self._create_ticket(self.team_a, user=self.user_own)
+        with Form(new_ticket.sudo()) as new_ticket_form:
+            new_ticket_form.stage_id = in_progress_stage
+            new_ticket_form.user_id = self.user
+        self.assertEqual(new_ticket_form.stage_id, in_progress_stage)


### PR DESCRIPTION
## Problem

`_compute_stage_id` unconditionally resets `stage_id` to the first
applicable stage of the team whenever it is triggered, even when the
current stage is already valid for that team.

Since `stage_id` depends on `team_id`, and `team_id` depends on
`user_id`, changing `user_id` on a ticket marks `team_id` as needing
recomputation, which in turn marks `stage_id` as needing
recomputation as well - even if `team_id` doesn't actually change
(e.g. reassigning a ticket to another agent within the same team).

As a result, simply reassigning a ticket to a different agent in the
same team resets its stage back to the first one, losing the actual
progress of the ticket.

## Solution

Only reset `stage_id` when the current stage is not part of the
applicable stages for the (possibly new) team. This preserves the
existing stage whenever it's still valid, while keeping the original
behavior when the team actually changes to one where the current
stage doesn't apply.

Verified `_get_applicable_stages()` correctly includes both
team-specific and shared/no-team stages, so this works consistently
across single-team, multi-team, and unassigned stage setups.

## Test

Added `test_stage_id_not_reset_on_user_change`, which fails without
the fix (stage reset to the first one) and passes with it.