### PR TITLE
[19.0][FIX] helpdesk_mgmt: Don't reset stage on user change

### DIFF
--- a/helpdesk_mgmt/models/helpdesk_ticket.py
+++ b/helpdesk_mgmt/models/helpdesk_ticket.py
@@ -19,8 +19,13 @@ class HelpdeskTicket(models.Model):
 
     @api.depends("team_id")
     def _compute_stage_id(self):
+        # This compute is executed on user change, even if not changing team, so let's
+        # apply a preventive check for not changing stage if the current one is still
+        # applicable to the current team
         for ticket in self:
-            ticket.stage_id = ticket.team_id._get_applicable_stages()[:1]
+            applicable_stages = ticket.team_id._get_applicable_stages()
+            if ticket.stage_id not in applicable_stages:
+                ticket.stage_id = applicable_stages[:1]
 
     @api.depends("team_id")
     def _compute_user_id(self):

--- a/helpdesk_mgmt/tests/test_helpdesk_ticket.py
+++ b/helpdesk_mgmt/tests/test_helpdesk_ticket.py
@@ -249,3 +249,13 @@ class TestHelpdeskTicket(TestHelpdeskTicketBase):
         wizard_rec.action_confirm()
         self.assertEqual(self.ticket.duplicate_id, self.ticket_b_unassigned)
         self.assertIn(self.ticket_b_unassigned.duplicate_ids, self.ticket)
+
+    def test_ticket_change_user_no_stage_reset(self):
+        in_progress_stage = self.env.ref(
+            "helpdesk_mgmt.helpdesk_ticket_stage_in_progress"
+        )
+        new_ticket = self._create_ticket(self.team_a, user=self.user_own)
+        with Form(new_ticket.sudo()) as new_ticket_form:
+            new_ticket_form.stage_id = in_progress_stage
+            new_ticket_form.user_id = self.user
+        self.assertEqual(new_ticket_form.stage_id, in_progress_stage)


### PR DESCRIPTION
Foward-port of #1055 and #814 

Steps to reproduce:

- Create a ticket in a specific team.
- Change the stage to one that is not the first.
- Assign user of the same team.

Result: the stage is reset to the first one.

Analysis: Even if the team is not changed, the `_compute_stage_id` method is executed. We don't want to remove computed writable methods, as they are very useful, so let's just do a preventive check on the compute method for not changing the stage if the current one is still applicable for the current team.

It includes a test for avoiding future regressions.

@Tecnativa 