### PR TITLE
[18.0][FIX] helpdesk_mgmt_timesheet: Remove undefined nbCols variable from timesheet_table

### DIFF
--- a/helpdesk_mgmt_timesheet/report/report_timesheet_templates.xml
+++ b/helpdesk_mgmt_timesheet/report/report_timesheet_templates.xml
@@ -23,13 +23,5 @@
             />
             </td>
         </xpath>
-        <xpath expr="//table[hasclass('table-sm')]/tbody/tr[2]/td" position="before">
-            <t
-                t-if="show_ticket"
-                t-set="nbCols"
-                t-value="nbCols + 1"
-                groups="helpdesk_mgmt.group_helpdesk_user"
-            />
-        </xpath>
     </template>
 </odoo>


### PR DESCRIPTION
In Odoo 17.0+ the parent template hr_timesheet.timesheet_table removed the nbCols variable (now using static colspan='100'). The inheritance was still trying to increment nbCols, causing a NameError when rendering the timesheet report with tickets linked to timesheet lines.

Related issue: https://github.com/OCA/helpdesk/issues/1057