### PR TITLE
[17.0][IMP] helpdesk_mgmt_portal_follower: Improve follower email splitting

### DIFF
--- a/helpdesk_mgmt_portal_follower/controllers/main.py
+++ b/helpdesk_mgmt_portal_follower/controllers/main.py
@@ -1,3 +1,5 @@
+import re
+
 import odoo.http as http
 from odoo.http import request
 
@@ -8,27 +10,43 @@ class HelpdeskTicketController(HelpdeskTicketController):
     @http.route("/submitted/ticket", type="http", auth="user", website=True, csrf=True)
     def submit_ticket(self, **kw):
         res = super().submit_ticket(**kw)
+
         ticket_id = res.location.split("/")[-1]
         new_ticket = request.env["helpdesk.ticket"].browse(int(ticket_id))
-        if kw.get("followers"):
-            emails = [
-                email.strip()
-                for email in kw.get("followers").split(",")
-                if email.strip()
-            ]
-            partner_ids = []
 
-            for email in emails:
-                partner = request.env["res.partner"].search([("email", "=", email)])
-                if not partner:
-                    reg = {
-                        "name": email,
-                        "email": email,
-                        "type": "contact",
-                    }
-                    partner = request.env["res.partner"].sudo().create(reg)
+        follower_emails = self._parse_follower_emails(kw.get("followers", ""))
 
-                partner_ids.append(partner.id)
+        partner_ids = []
 
-            new_ticket.sudo().message_subscribe(partner_ids=partner_ids)
+        for email in follower_emails:
+            partner = (
+                request.env["res.partner"]
+                .sudo()
+                .search(
+                    [("email", "=ilike", email)],
+                    limit=1,
+                )
+            )
+            if not partner:
+                reg = {
+                    "name": email,
+                    "email": email,
+                    "type": "contact",
+                }
+                partner = request.env["res.partner"].sudo().create(reg)
+
+            partner_ids.append(partner.id)
+
+        new_ticket.sudo().message_subscribe(partner_ids=partner_ids)
+
         return res
+
+    @staticmethod
+    def _parse_follower_emails(emails):
+        return list(
+            {
+                email.strip().lower()
+                for email in re.split(r"[\s,;]+", emails)
+                if email.strip()
+            }
+        )

--- a/helpdesk_mgmt_portal_follower/tests/test_ticket_followers.py
+++ b/helpdesk_mgmt_portal_follower/tests/test_ticket_followers.py
@@ -45,6 +45,45 @@ class TestSubmitPortalTicketBase(HttpCaseWithUserPortal):
         self.assertEqual(resp.status_code, response_code)
         return resp
 
+    def _submit_ticket(self, followers="", response_code=200, **values):
+        data = {
+            "category": self.category.id,
+            "csrf_token": http.Request.csrf_token(self),
+            "subject": self.new_ticket_title,
+            "description": self.new_ticket_description,
+            "followers": followers,
+        }
+        data.update(values)
+
+        response = self.url_open("/submitted/ticket", data=data)
+
+        self.assertEqual(response.status_code, response_code)
+
+        return response
+
+    def _get_created_ticket(self):
+        return self.helpdesk_ticket_model.search(
+            [("name", "=", self.new_ticket_title)],
+            limit=1,
+        )
+
+    def _assert_followers(self, ticket, emails):
+        for email in emails:
+            partner = self.partner_model.search(
+                [("email", "=ilike", email)],
+            )
+
+            self.assertEqual(
+                len(partner),
+                1,
+                f"Expected exactly one partner for {email}",
+            )
+            self.assertIn(
+                partner.id,
+                ticket.message_partner_ids.ids,
+                f"{email} is not subscribed to the ticket",
+            )
+
 
 class TestSubmitPortalTicket(TestSubmitPortalTicketBase):
     def test_submit_ticket_with_followers(self):
@@ -72,3 +111,140 @@ class TestSubmitPortalTicket(TestSubmitPortalTicketBase):
             partner = self.partner_model.search([("email", "=", email.strip())])
             self.assertEqual(len(partner), 0)
             self.assertNotIn(partner.id, ticket.message_partner_ids.ids)
+
+    def test_submit_ticket_with_comma_separated_followers(self):
+        self.authenticate("portal", "portal")
+
+        emails = [
+            "test1@testing.com",
+            "test2@testing.com",
+        ]
+
+        self._submit_ticket(
+            followers=", ".join(emails),
+        )
+
+        ticket = self._get_created_ticket()
+
+        self._assert_followers(ticket, emails)
+
+    def test_submit_ticket_with_semicolon_separated_followers(self):
+        self.authenticate("portal", "portal")
+
+        emails = [
+            "test1@testing.com",
+            "test2@testing.com",
+        ]
+
+        self._submit_ticket(
+            followers="; ".join(emails),
+        )
+
+        ticket = self._get_created_ticket()
+
+        self._assert_followers(ticket, emails)
+
+    def test_submit_ticket_with_space_separated_followers(self):
+        self.authenticate("portal", "portal")
+
+        emails = [
+            "test1@testing.com",
+            "test2@testing.com",
+        ]
+
+        self._submit_ticket(
+            followers=" ".join(emails),
+        )
+
+        ticket = self._get_created_ticket()
+
+        self._assert_followers(ticket, emails)
+
+    def test_submit_ticket_with_newline_separated_followers(self):
+        self.authenticate("portal", "portal")
+
+        emails = [
+            "test1@testing.com",
+            "test2@testing.com",
+        ]
+
+        self._submit_ticket(
+            followers="\n".join(emails),
+        )
+
+        ticket = self._get_created_ticket()
+
+        self._assert_followers(ticket, emails)
+
+    def test_submit_ticket_with_mixed_separators(self):
+        self.authenticate("portal", "portal")
+
+        emails = [
+            "test1@testing.com",
+            "test2@testing.com",
+            "test3@testing.com",
+            "test4@testing.com",
+        ]
+
+        self._submit_ticket(
+            followers=(
+                "test1@testing.com, "
+                "test2@testing.com; "
+                "test3@testing.com "
+                "test4@testing.com"
+            ),
+        )
+
+        ticket = self._get_created_ticket()
+
+        self._assert_followers(ticket, emails)
+
+    def test_submit_ticket_with_duplicate_followers(self):
+        self.authenticate("portal", "portal")
+
+        email = "test1@testing.com"
+
+        self._submit_ticket(
+            followers=("test1@testing.com, " "test1@testing.com; " "test1@testing.com"),
+        )
+
+        ticket = self._get_created_ticket()
+
+        partner = self.partner_model.search(
+            [("email", "=ilike", email)],
+        )
+
+        self.assertEqual(len(partner), 1)
+        self.assertIn(
+            partner.id,
+            ticket.message_partner_ids.ids,
+        )
+
+    def test_submit_ticket_reuses_existing_partner(self):
+        self.authenticate("portal", "portal")
+
+        existing_partner = self.partner_model.create(
+            {
+                "name": "Existing follower",
+                "email": "existing@testing.com",
+            }
+        )
+
+        self._submit_ticket(
+            followers="existing@testing.com",
+        )
+
+        ticket = self._get_created_ticket()
+
+        partners = self.partner_model.search(
+            [
+                ("email", "=ilike", "existing@testing.com"),
+            ]
+        )
+
+        self.assertEqual(len(partners), 1)
+        self.assertEqual(partners, existing_partner)
+        self.assertIn(
+            existing_partner.id,
+            ticket.message_partner_ids.ids,
+        )


### PR DESCRIPTION
Support multiple separators when processing portal ticket follower emails and add tests for the supported formats.

cc https://github.com/APSL 51163

@miquelalzanillas @lbarry-apsl @miquelpascual @peluko00 @javierobcn @ppyczko @cubells @isugac @palomagrc93 @shirashi3771 please review