### PR TITLE
[18.0][FIX] helpdesk_mgmt: preserve ticket stage on team change

### DIFF
--- a/helpdesk_mgmt/models/helpdesk_ticket.py
+++ b/helpdesk_mgmt/models/helpdesk_ticket.py
@@ -20,7 +20,11 @@ class HelpdeskTicket(models.Model):
     @api.depends("team_id")
     def _compute_stage_id(self):
         for ticket in self:
-            ticket.stage_id = ticket.team_id._get_applicable_stages()[:1]
+            applicable_stages = ticket.team_id._get_applicable_stages()
+            # Keep the current stage if it is still applicable in the newly assigned team.
+            if ticket.stage_id and ticket.stage_id in applicable_stages:
+                continue
+            ticket.stage_id = applicable_stages[:1]
 
     @api.depends("team_id")
     def _compute_user_id(self):

--- a/helpdesk_mgmt/tests/test_helpdesk_ticket.py
+++ b/helpdesk_mgmt/tests/test_helpdesk_ticket.py
@@ -173,6 +173,37 @@ class TestHelpdeskTicket(TestHelpdeskTicketBase):
         new_ticket.team_id = False
         self.assertEqual(new_ticket.stage_id, self.new_stage)
 
+    def test_ticket_stage_preserved_on_team_change(self):
+        """Stage should not change when re-assigning to another team
+        if the current stage is available in the new team as well.
+        """
+        # Create a stage shared between both teams
+        shared_stage = self.env["helpdesk.ticket.stage"].create(
+            {
+                "name": "In Progress (shared)",
+                "sequence": 5,
+                "team_ids": [(6, 0, [self.team_a.id, self.team_b.id])],
+            }
+        )
+        ticket = self.env["helpdesk.ticket"].create(
+            {
+                "name": "New Ticket",
+                "description": "Description",
+                "team_id": self.team_a.id,
+                "stage_id": shared_stage.id,
+            }
+        )
+        self.assertEqual(ticket.stage_id, shared_stage)
+        # Change the team to one that also has the current stage available.
+        # The stage should remain unchanged (no reset back to "New").
+        ticket.team_id = self.team_b
+        self.assertEqual(
+            ticket.stage_id,
+            shared_stage,
+            "Helpdesk Ticket: The stage should not change when re-assigning "
+            "to another team if the stage is available in both teams.",
+        )
+
     def test_ticket_without_team(self):
         new_ticket = self.env["helpdesk.ticket"].create(
             {


### PR DESCRIPTION
When a ticket was re-assigned to another team, the stage was reset back to the first applicable stage (e.g. 'New'), which re-triggered stage-based automatic emails. Now the current stage is kept if it is also applicable in the newly assigned team.