### PR TITLE
[18.0][IMP] helpdesk_mgmt_timesheet: show employee on ticket timesheets

### DIFF
--- a/helpdesk_mgmt_timesheet/views/helpdesk_ticket_view.xml
+++ b/helpdesk_mgmt_timesheet/views/helpdesk_ticket_view.xml
@@ -127,18 +127,19 @@
                     </group>
                     <field
                         name="timesheet_ids"
-                        context="{'default_project_id': project_id, 'default_task_id': task_id}"
+                        context="{'default_project_id': project_id, 'default_task_id': task_id, 'default_user_id': uid}"
                     >
                         <list editable="bottom" delete="true" default_order="date_time">
                             <field name="company_id" column_invisible="1" />
                             <field name="project_id" column_invisible="1" />
                             <field name="task_id" column_invisible="1" />
+                            <field name="user_id" column_invisible="1" />
                             <field name="date" widget="date" column_invisible="1" />
                             <field name="date_time" string="Date" required="1" />
                             <field
-                                name="user_id"
+                                name="employee_id"
                                 required="1"
-                                widget="many2one_avatar_user"
+                                widget="many2one_avatar_employee"
                             />
                             <field name="name" required="0" />
                             <field
@@ -169,6 +170,7 @@
                         <form>
                             <div class="oe_button_box" name="button_box">
                                 <field name="show_time_control" invisible="1" />
+                                <field name="user_id" invisible="1" />
                                 <button
                                     name="button_resume_work"
                                     string="Resume work"
@@ -192,7 +194,10 @@
                             </div>
                             <group>
                                 <field name="date" />
-                                <field name="user_id" widget="many2one_avatar_user" />
+                                <field
+                                    name="employee_id"
+                                    widget="many2one_avatar_employee"
+                                />
                                 <field name="name" />
                                 <field
                                     name="unit_amount"


### PR DESCRIPTION
This pull request updates the `helpdesk_ticket_view.xml` file to improve how timesheet entries are associated with users and employees. The main focus is on switching from user-based to employee-based fields and widgets, and ensuring that relevant user and employee information is properly set and displayed in the timesheet views.

**Employee and User Field Improvements:**

* The `timesheet_ids` context now includes `default_user_id` to automatically set the current user when creating new timesheet entries.
* The timesheet list now includes the `user_id` field as a hidden column for reference.
* The editable field for assigning timesheet entries has been changed from `user_id` (with the `many2one_avatar_user` widget) to `employee_id` (with the `many2one_avatar_employee` widget), reflecting a shift to employee-based assignment.
* In the timesheet form view, the employee selection uses the `employee_id` field and the `many2one_avatar_employee` widget instead of the user-based field and widget.

**User Field Visibility:**

* The `user_id` field is now included as an invisible field in the button box section of the form, ensuring the user reference is available for backend logic without displaying it to the user.