### PR TITLE
[FIX] helpdesk_portal_priority: use _get_create_new_ticket_values hook

### DIFF
--- a/helpdesk_portal_priority/__manifest__.py
+++ b/helpdesk_portal_priority/__manifest__.py
@@ -2,7 +2,7 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 {
     "name": "Helpdesk Portal Priority",
-    "version": "18.0.1.0.0",
+    "version": "18.0.1.0.1",
     "category": "Helpdesk",
     "website": "https://github.com/OCA/helpdesk",
     "author": "Lansana Barry Sow, APSL-Nagarro, Odoo Community Association (OCA)",

--- a/helpdesk_portal_priority/controllers/main.py
+++ b/helpdesk_portal_priority/controllers/main.py
@@ -8,16 +8,14 @@ _logger = logging.getLogger(__name__)
 
 
 class HelpdeskPriorityController(HelpdeskTicketController):
-    @http.route("/new/ticket", type="http", auth="user", website=True)
-    def create_new_ticket(self, **kw):
-        res = super().create_new_ticket(**kw)
-        priorities = (
+    def _get_create_new_ticket_values(self, **kw):
+        values = super()._get_create_new_ticket_values(**kw)
+        values["priorities"] = (
             http.request.env["helpdesk.ticket"]
             ._fields["priority"]
             ._description_selection(http.request.env)
         )
-        res.qcontext["priorities"] = priorities
-        return res
+        return values
 
     def _prepare_submit_ticket_vals(self, **kw):
         vals = super()._prepare_submit_ticket_vals(**kw)

--- a/helpdesk_portal_priority/tests/__init__.py
+++ b/helpdesk_portal_priority/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_helpdesk_portal_priority

--- a/helpdesk_portal_priority/tests/test_helpdesk_portal_priority.py
+++ b/helpdesk_portal_priority/tests/test_helpdesk_portal_priority.py
@@ -1,0 +1,12 @@
+from odoo.tests.common import tagged
+
+from odoo.addons.base.tests.common import HttpCaseWithUserPortal
+
+
+@tagged("post_install", "-at_install")
+class TestHelpdeskPortalPriority(HttpCaseWithUserPortal):
+    def test_new_ticket_form_has_priority_selector(self):
+        self.authenticate("portal", "portal")
+        resp = self.url_open("/new/ticket")
+        self.assertEqual(resp.status_code, 200)
+        self.assertIn('name="priority"', resp.text)


### PR DESCRIPTION
`create_new_ticket` used to override the whole `/new/ticket` route, call
`super().create_new_ticket(**kw)`, and then mutate `res.qcontext["priorities"]`
on the already-rendered response.

This switches to overriding `_get_create_new_ticket_values`, the extension
point that `helpdesk_mgmt` now provides for this exact purpose: adding values
to the ticket creation form without re-implementing the whole route.

cc https://github.com/APSL

@shirashi3771 @lbarry-apsl @miquelalzanillas @peluko00 @BernatObrador @cubells @miquelpascual @ppyczko @isugac @javierobcn please review.
