### PR TITLE
[FIX] helpdesk_portal_restriction: use _get_create_new_ticket_values_get_categories

### DIFF
--- a/helpdesk_portal_restriction/__manifest__.py
+++ b/helpdesk_portal_restriction/__manifest__.py
@@ -2,7 +2,7 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 {
     "name": "Helpdesk Portal Restriction",
-    "version": "18.0.1.0.0",
+    "version": "18.0.1.0.1",
     "category": "Helpdesk",
     "website": "https://github.com/OCA/helpdesk",
     "author": "Lansana Barry Sow, APSL-Nagarro, Odoo Community Association (OCA)",

--- a/helpdesk_portal_restriction/controllers/main.py
+++ b/helpdesk_portal_restriction/controllers/main.py
@@ -1,7 +1,6 @@
 import logging
 
 import odoo.http as http
-from odoo.http import request
 
 from odoo.addons.helpdesk_mgmt.controllers.main import HelpdeskTicketController
 
@@ -21,34 +20,11 @@ class HelpdeskPartnerTeamCategoryController(HelpdeskTicketController):
         else:
             return False
 
-    def _get_category(self):
+    def _get_categories(self, **kw):
         return (
             http.request.env.user.partner_id.helpdesk_category_ids
             if http.request.env.user.partner_id.helpdesk_category_ids
             else http.request.env["helpdesk.ticket.category"].search(
                 [("active", "=", True)]
             )
-        )
-
-    @http.route("/new/ticket", type="http", auth="user", website=True)
-    def create_new_ticket(self, **kw):
-        session_info = http.request.env["ir.http"].session_info()
-        email = http.request.env.user.email
-        name = http.request.env.user.name
-        company = request.env.company
-        return http.request.render(
-            "helpdesk_mgmt.portal_create_ticket",
-            {
-                "categories": self._get_category(),
-                "teams": self._get_teams(),
-                "email": email,
-                "name": name,
-                "ticket_team_id_required": (
-                    company.helpdesk_mgmt_portal_team_id_required
-                ),
-                "ticket_category_id_required": (
-                    company.helpdesk_mgmt_portal_category_id_required
-                ),
-                "max_upload_size": session_info["max_file_upload_size"],
-            },
         )


### PR DESCRIPTION
`create_new_ticket` used to override the whole `/new/ticket` route and
render the response directly, without calling `super()`. It also used
`_get_category()` (old, singular name) instead of the base controller's
current `_get_categories(self, **kw)` (plural, with `**kw`).

This removes the `create_new_ticket` override entirely and renames
`_get_category` to `_get_categories(self, **kw)`, matching the extension
point that `helpdesk_mgmt` now provides.

cc https://github.com/APSL

@shirashi3771 @lbarry-apsl @miquelalzanillas @peluko00 @BernatObrador @cubells @miquelpascual @ppyczko @isugac @javierobcn please review.