### PR TITLE
[18.0][FIX] helpdesk_mgmt_timesheet: Prevent an error if the user does not have access to the project

### DIFF
--- a/helpdesk_mgmt_timesheet/models/helpdesk_ticket.py
+++ b/helpdesk_mgmt_timesheet/models/helpdesk_ticket.py
@@ -86,8 +86,12 @@ class HelpdeskTicket(models.Model):
     def _compute_show_time_control(self):
         result = super()._compute_show_time_control()
         for ticket in self:
+            # We use sudo() for the project because the ticket user may not have
+            # permission to access it—for example, if the project is visible to
+            # invited internal users and the ticket user is not one of them
             if not (
-                ticket.project_id.allow_timesheets and ticket.team_id.allow_timesheet
+                ticket.project_id.sudo().allow_timesheets
+                and ticket.team_id.allow_timesheet
             ):
                 ticket.show_time_control = False
         return result


### PR DESCRIPTION
Prevent an error if the user does not have access to the project

Use case example:
- Create a user with permissions under Helpdesk and Project > User
- Create a project with visibility set to Invited internal users (private)
- Create a ticket linked to the previously created user and project
- When attempting to access the ticket with the created user, the user should be able to access it successfully without any errors being displayed

Please @pilarvargas-tecnativa and @pedrobaeza can you review it?

@Tecnativa TT63960