### PR TITLE
[19.0][FIX] helpdesk_ticket_close_inactive: don't require warning template when disabled

### DIFF
--- a/helpdesk_ticket_close_inactive/views/helpdesk_ticket_team.xml
+++ b/helpdesk_ticket_close_inactive/views/helpdesk_ticket_team.xml
@@ -24,7 +24,7 @@
                             <field
                                 name="warning_inactive_mail_template_id"
                                 domain="[('model', '=', 'helpdesk.ticket')]"
-                                required="inactive_tickets_day_limit_warning > 0"
+                                required="close_inactive_tickets and inactive_tickets_day_limit_warning > 0"
                                 invisible="inactive_tickets_day_limit_warning == 0"
                             />
                         </group>


### PR DESCRIPTION
Forward port of #1066.