### PR TITLE
[18.0][FIX] helpdesk_mgmt_project: migrate plain column to company dependent field

### DIFF
--- a/helpdesk_mgmt_project/migrations/18.0.1.0.0/post-migration.py
+++ b/helpdesk_mgmt_project/migrations/18.0.1.0.0/post-migration.py
@@ -8,3 +8,30 @@ def migrate(env, version):
     openupgrade_180.convert_company_dependent(
         env, "helpdesk.ticket.team", "default_project_id"
     )
+    _convert_from_legacy_column(env)
+
+
+def _convert_from_legacy_column(env):
+    """Convert values coming from a plain (non company dependent) column.
+
+    ``convert_company_dependent()`` only reads ``ir_property`` rows, which
+    exist when the field was already company dependent before 18.0. When
+    the database comes from a version where the field was a regular
+    many2one, the values live in the integer column renamed by the
+    pre-migration; assign them to the team's company (or the current
+    company when the team has none).
+    """
+    legacy = openupgrade.get_legacy_name("default_project_id")
+    if not openupgrade.column_exists(env.cr, "helpdesk_ticket_team", legacy):
+        return
+    openupgrade.logged_query(
+        env.cr,
+        f"""
+        UPDATE helpdesk_ticket_team t
+        SET default_project_id = jsonb_build_object(
+            COALESCE(t.company_id, %s)::text, t.{legacy}
+        )
+        WHERE t.{legacy} IS NOT NULL AND t.default_project_id IS NULL
+        """,
+        (env.company.id,),
+    )

--- a/helpdesk_mgmt_project/migrations/18.0.1.0.0/pre-migration.py
+++ b/helpdesk_mgmt_project/migrations/18.0.1.0.0/pre-migration.py
@@ -1,0 +1,29 @@
+# Copyright 2026 PopSolutions
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+from openupgradelib import openupgrade
+
+_TABLE = "helpdesk_ticket_team"
+_COLUMN = "default_project_id"
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    """Rename the legacy integer column before the ORM loads the field.
+
+    ``default_project_id`` became ``company_dependent`` (stored as jsonb)
+    in 18.0. A database migrated straight from a version where it was a
+    regular many2one still has an integer column, and the ORM crashes
+    trying to ``ALTER ... TYPE jsonb USING ...::jsonb``.
+    """
+    if not openupgrade.column_exists(env.cr, _TABLE, _COLUMN):
+        return
+    env.cr.execute(
+        """
+        SELECT data_type FROM information_schema.columns
+        WHERE table_name = %s AND column_name = %s
+        """,
+        (_TABLE, _COLUMN),
+    )
+    row = env.cr.fetchone()
+    if row and row[0] != "jsonb":
+        openupgrade.rename_columns(env.cr, {_TABLE: [(_COLUMN, None)]})


### PR DESCRIPTION
`default_project_id` on `helpdesk.ticket.team` became `company_dependent` (stored as jsonb) in 18.0. A database migrated straight from a version where the field was a regular many2one still has an **integer** column, and the ORM crashes while loading the field:

```
psycopg2.errors.CannotCoerce: cannot cast type integer to jsonb
LINE 1: ... TYPE jsonb USING "default_project_id"::jsonb
```

The existing `18.0.1.0.0` post-migration only handles the 17.0 → 18.0 case (it reads `ir_property` rows through `openupgrade_180.convert_company_dependent`). Databases where the field was never company dependent have no `ir_property` rows — their values live in the plain column and are lost, after the crash above is somehow worked around.

This PR:

* adds a **pre-migration** that renames the legacy column before the ORM loads the field — guarded by `column_exists` and a data-type check, so it is idempotent and a no-op for databases coming from 17.0;
* extends the **post-migration** to also convert the legacy column values, assigning them to the team's company (falling back to the current company).

Found on a real 16.0 → 18.0 OpenUpgrade migration; with these scripts that database migrates cleanly.
