### PR TITLE
[FIX] helpdesk_mgmt: do not auto-assign tickets to portal users

### DIFF
--- a/helpdesk_mgmt/models/helpdesk_ticket.py
+++ b/helpdesk_mgmt/models/helpdesk_ticket.py
@@ -203,7 +203,14 @@ class HelpdeskTicket(models.Model):
         # If the team is set, the user must belong to that team.
         defaults = super().default_get(fields)
         company_id = defaults.get("company_id") or self.env.company.id
-        if "user_id" in fields and not defaults.get("user_id"):
+        # A shared user (portal, public) is never a valid assignee: the
+        # user_id domain already excludes them, and a portal customer must
+        # not end up assigned to the ticket they just submitted.
+        if (
+            "user_id" in fields
+            and not defaults.get("user_id")
+            and not self.env.user.share
+        ):
             company = self.env["res.company"].browse(company_id)
             if company.helpdesk_mgmt_ticket_auto_assign:
                 if defaults.get("team_id"):

--- a/helpdesk_mgmt/tests/test_helpdesk_portal.py
+++ b/helpdesk_mgmt/tests/test_helpdesk_portal.py
@@ -185,6 +185,22 @@ class TestHelpdeskPortal(TestHelpdeskPortalBase):
         self.assertEqual(resp.status_code, 200)
         self.assertIn("ticket-user-2", resp.text)
 
+    def test_portal_user_is_not_auto_assigned(self):
+        """A ticket created by a portal user is not assigned to them."""
+        # Not submitted through our own controller on purpose: it passes
+        # "user_id": False explicitly, so it never reaches the auto-assign
+        # default. This covers any other creator that leaves user_id out,
+        # such as a custom website form or an API import.
+        self.env.company.helpdesk_mgmt_ticket_auto_assign = True
+        # sudo() keeps env.uid: this is what portal controllers do.
+        ticket = (
+            self.env["helpdesk.ticket"]
+            .with_user(self.user_portal)
+            .sudo()
+            .create({"name": "Ticket", "description": "Description"})
+        )
+        self.assertFalse(ticket.user_id)
+
     def _count_close_buttons(self, resp) -> int:
         """Count close buttons in a form by counting forms with that target."""
         return resp.text.count('action="/ticket/close"')


### PR DESCRIPTION
## Problem

When *Auto assign User* is enabled on the company, a ticket submitted by a
portal user ends up assigned to that portal user. The customer who filed the
ticket becomes its assignee, which also means the ticket counts as assigned
and never shows up as unassigned, so nobody picks it up.

## How to reproduce

1. Enable *Auto assign User* on the company.
2. Reproduce what a portal controller does:

```python
env["helpdesk.ticket"].with_user(portal_user).sudo().create({
    "name": "Portal ticket",
    "description": "<p>...</p>",
    "team_id": team.id,
})
```

The ticket is created with `user_id` set to the portal user.

Note that `sudo()` does not change `env.uid`, it only elevates privileges, so
`self.env.user` inside `default_get()` is still the portal user.

## Cause

`helpdesk_mgmt/models/helpdesk_ticket.py`, `default_get()`:

```python
if "user_id" in fields and not defaults.get("user_id"):
    company = self.env["res.company"].browse(company_id)
    if company.helpdesk_mgmt_ticket_auto_assign:
        if defaults.get("team_id"):
            team = ...
            if self.env.user in team.user_ids:
                defaults["user_id"] = self.env.user.id
        else:
            defaults["user_id"] = self.env.user.id
```

The branch with a team is safe by accident: a portal user is not a member of
the team, so the membership check rejects it. The branch without a team
assigns unconditionally.

Portal controllers hit that second branch, because they pass the team in the
*values* of `create()` and not in the defaults: `team_id` is therefore not a
missing field, `default_get()` is not called for it, and
`defaults.get("team_id")` is falsy.

`helpdesk_mgmt`'s own portal controller happens to escape the issue, because
`_prepare_submit_ticket_vals()` sets `"user_id": False` explicitly. Any other
controller that does not set it — a custom website form, an API import — hits
the bug. A website form with `auth="public"` runs as `base.public_user`, so
in that case tickets end up assigned to the public user, which is even less
useful than being assigned to the customer.

## Fix

Skip the auto-assignment when the current user is a shared user
(`share == True`, i.e. portal or public). This is consistent with the domain
of `user_id` itself, which already excludes shared users:

```python
domain="team_id and [('share', '=', False),('id', 'in', user_ids)] or [('share', '=', False)]"
```

Internal users are unaffected: the existing behaviour (creator becomes the
assignee) is preserved, and a regression test covers it.

## Tests

Four tests added to `helpdesk_mgmt/tests/test_helpdesk_portal.py`, reusing the
existing `TestHelpdeskPortalBase` fixtures: portal user with and without a
team, `base.public_user`, and an internal user to make sure the current
behaviour does not change.

## Other branches

The same code is present in `17.0`. `16.0` is not affected: the
`helpdesk_mgmt_ticket_auto_assign` field does not exist there. Happy to
backport to `17.0` if you want it in the same PR or in a separate one.
