### PR TITLE
[18.0][FW] [17.0][FIX] helpdesk_ticket_close_inactive: fix autoclose loop for multiple teams

### DIFF
--- a/.oca/oca-port/blacklist/helpdesk_ticket_close_inactive.json
+++ b/.oca/oca-port/blacklist/helpdesk_ticket_close_inactive.json
@@ -1,0 +1,5 @@
+{
+  "pull_requests": {
+    "OCA/helpdesk#705": "Migration to v17"
+  }
+}

--- a/helpdesk_ticket_close_inactive/models/helpdesk_ticket_team.py
+++ b/helpdesk_ticket_close_inactive/models/helpdesk_ticket_team.py
@@ -83,6 +83,9 @@ class HelpdeskTicketTeam(models.Model):
         else:
             teams = self.search([("close_inactive_tickets", "=", True)])
 
+        warning_email_ids = []
+        closing_email_ids = []
+
         for team_id in teams:
             ticket_stage_ids = team_id.ticket_stage_ids.ids
             ticket_category_ids = team_id.ticket_category_ids.ids
@@ -90,8 +93,6 @@ class HelpdeskTicketTeam(models.Model):
                 days=team_id.inactive_tickets_day_limit_closing
             )
             closing_stage = team_id.closing_ticket_stage
-            warning_email_ids = []
-            closing_email_ids = []
 
             # Warning phase — only active when warning day limit is greater than 0
             if team_id.inactive_tickets_day_limit_warning > 0:
@@ -163,7 +164,7 @@ class HelpdeskTicketTeam(models.Model):
                                 ticket.number,
                             )
                             closing_email_ids.append(closing_email_id)
-            return {
-                "warning_email_ids": warning_email_ids,
-                "closing_email_ids": closing_email_ids,
-            }
+        return {
+            "warning_email_ids": warning_email_ids,
+            "closing_email_ids": closing_email_ids,
+        }

--- a/helpdesk_ticket_close_inactive/tests/test_ticket_autoclose.py
+++ b/helpdesk_ticket_close_inactive/tests/test_ticket_autoclose.py
@@ -43,6 +43,31 @@ class TestHelpdeskTicketAutoclose(BaseCommon):
             }
         )
 
+        self.team2 = self.env["helpdesk.ticket.team"].create(
+            {
+                "name": "Test Team 2",
+                "close_inactive_tickets": True,
+                "inactive_tickets_day_limit_warning": 7,
+                "inactive_tickets_day_limit_closing": 14,
+            }
+        )
+        self.team2.ticket_stage_ids = [(4, self.stage_warning.id)]
+        self.team2.closing_ticket_stage = self.stage_closing
+        self.remaining_days = (
+            self.team2.inactive_tickets_day_limit_closing
+            - self.team2.inactive_tickets_day_limit_warning
+        )
+        self.ticket2 = self.env["helpdesk.ticket"].create(
+            {
+                "name": "Test Ticket 2",
+                "team_id": self.team2.id,
+                "stage_id": self.stage_warning.id,
+                "category_id": self.type_warning.id,
+                "description": "Please help me 2",
+                "last_stage_update": datetime.today() - timedelta(days=7),
+            }
+        )
+
     def test_warning_email_sent(self):
         """Test that a warning email is sent after the warning day limit is reached."""
         self.ticket.write({"last_stage_update": datetime.today() - timedelta(days=7)})
@@ -142,4 +167,29 @@ class TestHelpdeskTicketAutoclose(BaseCommon):
             self.stage_closing,
             "Ticket without a category should also be closed "
             "when no category filter is set.",
+        )
+
+    def test_multiple_teams_processed_by_cron(self):
+        """Test that the cron processes all active teams in a single execution."""
+        self.ticket.write({"last_stage_update": datetime.today() - timedelta(days=15)})
+        self.ticket2.write({"last_stage_update": datetime.today() - timedelta(days=15)})
+        result = self.env["helpdesk.ticket.team"].close_team_inactive_tickets()
+
+        # Assert BOTH tickets were successfully updated to the closing stage
+        self.assertEqual(
+            self.ticket.stage_id,
+            self.stage_closing,
+            "First team ticket should be closed by multi-team cron process.",
+        )
+        self.assertEqual(
+            self.ticket2.stage_id,
+            self.stage_closing,
+            "Second team ticket should be closed by multi-team cron process.",
+        )
+
+        # Assert exactly 2 closing emails were tracked (one per closed ticket)
+        self.assertEqual(
+            len(result.get("closing_email_ids", [])),
+            2,
+            "The cron should have tracked exactly 2 closing email IDs.",
         )


### PR DESCRIPTION
Port from 17.0 to 18.0:
- #1021

The following PRs have been blacklisted:
- #705: Migration to v17

cc https://github.com/APSL 53514

@miquelalzanillas @lbarry-apsl @miquelpascual @peluko00 @javierobcn @BernatObrador @cubells @palomagrc93 @shirashi3771 please review