### PR TITLE
[FIX] helpdesk_mgmt: enforce access control on /ticket/close (portal can change arbitrary tickets)

### DIFF
--- a/helpdesk_mgmt/__manifest__.py
+++ b/helpdesk_mgmt/__manifest__.py
@@ -4,7 +4,7 @@
     "name": "Helpdesk Management",
     "summary": """
         Helpdesk""",
-    "version": "19.0.1.1.1",
+    "version": "19.0.1.1.2",
     "license": "AGPL-3",
     "category": "After-Sales",
     "author": "AdaptiveCity, "

--- a/helpdesk_mgmt/controllers/main.py
+++ b/helpdesk_mgmt/controllers/main.py
@@ -20,14 +20,14 @@ class HelpdeskTicketController(http.Controller):
                 values[field_name] = int(field_value)
             else:
                 values[field_name] = field_value
-        ticket = (
-            http.request.env["helpdesk.ticket"]
-            .sudo()
-            .search([("id", "=", values["ticket_id"])])
-        )
+        ticket = http.request.env["helpdesk.ticket"].search(
+            [("id", "=", values["ticket_id"])]
+        )  # no sudo(): record rules restrict this to tickets the caller may access
+        if not ticket:
+            return werkzeug.utils.redirect("/my")
         stage = http.request.env["helpdesk.ticket.stage"].browse(values.get("stage_id"))
         if stage.close_from_portal:  # protect against invalid target stage request
-            ticket.stage_id = values.get("stage_id")
+            ticket.sudo().stage_id = values.get("stage_id")  # ownership enforced above
 
         return werkzeug.utils.redirect("/my/ticket/" + str(ticket.id))
 

--- a/helpdesk_mgmt/tests/__init__.py
+++ b/helpdesk_mgmt/tests/__init__.py
@@ -5,3 +5,4 @@ from . import test_helpdesk_fetchmail
 from . import test_res_partner
 from . import test_helpdesk_category_hierarchy
 from . import test_js
+from . import test_helpdesk_ticket_close_acl

--- a/helpdesk_mgmt/tests/test_helpdesk_ticket_close_acl.py
+++ b/helpdesk_mgmt/tests/test_helpdesk_ticket_close_acl.py
@@ -1,0 +1,75 @@
+# Copyright 2026 Grégory Mariani
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+from odoo.tests.common import tagged
+
+from odoo.addons.base.tests.common import (
+    DISABLED_MAIL_CONTEXT,
+    HttpCaseWithUserPortal,
+)
+
+
+@tagged("post_install", "-at_install")
+class TestHelpdeskTicketCloseACL(HttpCaseWithUserPortal):
+    """Regression test for the /ticket/close access-control fix.
+
+    The controller used to fetch the ticket with sudo() and only check the
+    target stage's close_from_portal flag, letting a portal user change the
+    stage of any ticket by passing an arbitrary ticket_id. The fix fetches the
+    ticket as the current user so record rules apply.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.env = cls.env(context=dict(cls.env.context, **DISABLED_MAIL_CONTEXT))
+        cls.stage_open = cls.env.ref("helpdesk_mgmt.helpdesk_ticket_stage_new")
+        cls.stage_close = cls.env.ref("helpdesk_mgmt.helpdesk_ticket_stage_done")
+        # A partner unrelated to the portal user: its ticket is out of reach.
+        cls.victim_partner = cls.env["res.partner"].create({"name": "Victim Corp ACL"})
+        cls.victim_ticket = cls.env["helpdesk.ticket"].create(
+            {
+                "name": "victim-acl-ticket",
+                "description": "victim",
+                "partner_id": cls.victim_partner.id,
+                "stage_id": cls.stage_open.id,
+            }
+        )
+        # A ticket the portal user legitimately owns.
+        cls.own_ticket = cls.env["helpdesk.ticket"].create(
+            {
+                "name": "own-acl-ticket",
+                "description": "mine",
+                "partner_id": cls.partner_portal.id,
+                "stage_id": cls.stage_open.id,
+            }
+        )
+
+    def _close(self, ticket, stage):
+        return self.url_open(f"/ticket/close?ticket_id={ticket.id}&stage_id={stage.id}")
+
+    def test_portal_cannot_close_foreign_ticket(self):
+        # Precondition: the record rule already hides the ticket from the ORM.
+        self.assertFalse(
+            self.env["helpdesk.ticket"]
+            .with_user(self.user_portal)
+            .search([("id", "=", self.victim_ticket.id)]),
+            "test setup invalid: portal user can read the victim ticket",
+        )
+        self.authenticate("portal", "portal")
+        self._close(self.victim_ticket, self.stage_close)
+        self.victim_ticket.invalidate_recordset()
+        self.assertEqual(
+            self.victim_ticket.stage_id,
+            self.stage_open,
+            "a portal user must not change the stage of a ticket it cannot access",
+        )
+
+    def test_portal_can_close_own_ticket(self):
+        self.authenticate("portal", "portal")
+        self._close(self.own_ticket, self.stage_close)
+        self.own_ticket.invalidate_recordset()
+        self.assertEqual(
+            self.own_ticket.stage_id,
+            self.stage_close,
+            "a portal user must still be able to close its own ticket",
+        )


### PR DESCRIPTION
## [FIX] helpdesk_mgmt: enforce access control on `/ticket/close`

### Security impact

Broken access control / IDOR (CWE-639) in the `/ticket/close` portal controller.

The `support_ticket_close` controller fetches the ticket with `sudo()`, which
bypasses the `helpdesk.ticket` record rules (portal "own tickets" and the
multi-company rule), and then gates the write only on the **target stage's**
`close_from_portal` flag - not on whether the caller may act on that ticket:

```python
ticket = (
    request.env["helpdesk.ticket"].sudo()
    .search([("id", "=", values["ticket_id"])])   # ticket_id is attacker-controlled
)
stage = request.env["helpdesk.ticket.stage"].browse(values.get("stage_id"))
if stage.close_from_portal:                        # checks the stage, not the caller
    ticket.stage_id = values.get("stage_id")
```

As a result, **any authenticated portal or internal user can change the stage
of any other tenant's ticket** by passing an arbitrary `ticket_id` together
with a `stage_id` whose `close_from_portal` is `True` (the default `Done`,
`Cancelled` and `Rejected` stages qualify), even for tickets they cannot read.
The exploit is a plain `GET /ticket/close?ticket_id=<any>&stage_id=<close>`.

### Fix

Fetch the ticket as the current user so record rules constrain which tickets
the caller can act on; keep `sudo()` only for the stage write, once access to
the record has been established (so a portal user without write permission can
still close a ticket they legitimately own).

### Tests

Adds `test_helpdesk_ticket_close_acl.py`:
- a portal user cannot close a ticket it cannot access (stage stays unchanged);
- a portal user can still close its own ticket (legitimate flow preserved).

### Affected versions

Same vulnerable route on **16.0, 17.0, 18.0, 19.0**. This PR targets 19.0; I am
happy to port it to the other branches.

