### PR TITLE
[IMP] helpdesk_mgmt_fieldservice: review fsm_order_close_wizard security

### DIFF
--- a/helpdesk_mgmt_fieldservice/models/fsm_order.py
+++ b/helpdesk_mgmt_fieldservice/models/fsm_order.py
@@ -13,7 +13,8 @@ class FSMOrder(models.Model):
     def action_complete(self):
         res = super().action_complete()
         if (
-            not self.ticket_id.stage_id.closed
+            self.ticket_id.has_access("write")
+            and not self.ticket_id.stage_id.closed
             and self.ticket_id.fsm_order_ids
             and all(self.ticket_id.mapped("fsm_order_ids.stage_id.is_closed"))
         ):
@@ -24,7 +25,6 @@ class FSMOrder(models.Model):
                 "target": "new",
                 "context": {
                     "default_ticket_id": self.ticket_id.id,
-                    "default_team_id": self.ticket_id.team_id.id,
                     "default_resolution": self.resolution,
                 },
             }

--- a/helpdesk_mgmt_fieldservice/models/fsm_order.py
+++ b/helpdesk_mgmt_fieldservice/models/fsm_order.py
@@ -12,11 +12,12 @@ class FSMOrder(models.Model):
 
     def action_complete(self):
         res = super().action_complete()
+        tickets = self.ticket_id
         if (
-            self.ticket_id.has_access("write")
-            and not self.ticket_id.stage_id.closed
-            and self.ticket_id.fsm_order_ids
-            and all(self.ticket_id.mapped("fsm_order_ids.stage_id.is_closed"))
+            tickets.has_access("write")
+            and not tickets.stage_id.closed
+            and tickets.fsm_order_ids
+            and all(tickets.mapped("fsm_order_ids.stage_id.is_closed"))
         ):
             return {
                 "view_mode": "form",
@@ -24,7 +25,7 @@ class FSMOrder(models.Model):
                 "type": "ir.actions.act_window",
                 "target": "new",
                 "context": {
-                    "default_ticket_id": self.ticket_id.id,
+                    "default_ticket_id": tickets.id,
                     "default_resolution": self.resolution,
                 },
             }

--- a/helpdesk_mgmt_fieldservice/security/ir.model.access.csv
+++ b/helpdesk_mgmt_fieldservice/security/ir.model.access.csv
@@ -1,3 +1,3 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
 access_helpdesk_ticket_fsm_user,helpdesk.ticket.fsm.user,model_helpdesk_ticket,fieldservice.group_fsm_user,1,0,0,0
-access_fsm_order_close_wizard,fsm.order.close.wizard,model_fsm_order_close_wizard,fieldservice.group_fsm_user,1,1,1,0
+access_fsm_order_close_wizard,fsm.order.close.wizard,model_fsm_order_close_wizard,fieldservice.group_fsm_user_own,1,1,1,0

--- a/helpdesk_mgmt_fieldservice/tests/test_helpdesk_ticket_fsm_order.py
+++ b/helpdesk_mgmt_fieldservice/tests/test_helpdesk_ticket_fsm_order.py
@@ -7,6 +7,7 @@ from odoo.exceptions import ValidationError
 from odoo.tests import Form, TransactionCase
 
 from odoo.addons.base.tests.common import DISABLED_MAIL_CONTEXT
+from odoo.addons.mail.tests.common import mail_new_test_user
 
 
 class TestHelpdeskTicketFSMOrder(TransactionCase):
@@ -16,6 +17,13 @@ class TestHelpdeskTicketFSMOrder(TransactionCase):
         cls.env = cls.env(context=dict(cls.env.context, **DISABLED_MAIL_CONTEXT))
         cls.partner = cls.env["res.partner"].create({"name": "Partner 1"})
         cls.user_demo = cls.env.ref("base.user_demo")
+        cls.all_doc_group_xmlid = "fieldservice.group_fsm_user"
+        cls.own_doc_group_xmlid = "fieldservice.group_fsm_user_own"
+        cls.own_doc_user = mail_new_test_user(
+            cls.env,
+            login="test fieldservice user own documents",
+            groups=cls.own_doc_group_xmlid,
+        )
         cls.fsm_team = cls.env["fsm.team"].create({"name": "FSM Team"})
         cls.fsm_stage_new = cls.env.ref("fieldservice.fsm_stage_new")
         cls.fsm_stage_cancelled = cls.env.ref("fieldservice.fsm_stage_cancelled")
@@ -132,7 +140,6 @@ class TestHelpdeskTicketFSMOrder(TransactionCase):
             action_complete_last_order["context"],
             {
                 "default_ticket_id": self.ticket_1.id,
-                "default_team_id": self.team_id.id,
                 "default_resolution": Markup("<p>Just another resolution</p>"),
             },
         )
@@ -201,3 +208,20 @@ class TestHelpdeskTicketFSMOrder(TransactionCase):
             ValidationError, "Please complete all service orders"
         ):
             self.ticket_1.stage_id = self.stage_closed
+
+    def test_user_own_close_wizard(self):
+        """A user that can only access their own documents,
+        can close an order."""
+        # Arrange
+        user = self.own_doc_user
+        fsm_order = self._create_ticket_fsm_orders(self.ticket_1)
+        # pre-condition
+        self.assertNotEqual(fsm_order.stage_id, self.stage_completed)
+        self.assertTrue(user.has_group(self.own_doc_group_xmlid))
+        self.assertFalse(user.has_group(self.all_doc_group_xmlid))
+
+        # Act
+        fsm_order.with_user(user).action_complete()
+
+        # Assert
+        self.assertEqual(fsm_order.stage_id, self.stage_completed)

--- a/helpdesk_mgmt_fieldservice/wizards/fsm_order_close_wizard.py
+++ b/helpdesk_mgmt_fieldservice/wizards/fsm_order_close_wizard.py
@@ -10,7 +10,6 @@ class FSMOrderCloseWizard(models.TransientModel):
     _description = "FSM Close - Option to Close Ticket"
 
     resolution = fields.Html()
-    team_id = fields.Many2one("helpdesk.ticket.team", string="Helpdesk Team")
     stage_id = fields.Many2one("helpdesk.ticket.stage", string="Stage")
     ticket_id = fields.Many2one("helpdesk.ticket", string="Ticket")
 

--- a/helpdesk_mgmt_fieldservice/wizards/fsm_order_close_wizard.xml
+++ b/helpdesk_mgmt_fieldservice/wizards/fsm_order_close_wizard.xml
@@ -11,13 +11,7 @@
                   There is an open Ticket, would you like to update the related ticket?
               </div>
                 <group>
-                    <field name="team_id" invisible="1" />
                     <field name="ticket_id" invisible="1" />
-                    <!--                  <field name="stage_id"-->
-                    <!--                         string="Ticket Stage"-->
-                    <!--                         required="1"-->
-                    <!--                         domain="[('team_ids', '=', team_id)]"-->
-                    <!--                         options="{'no_create': True, 'no_open': True, 'no_create_edit': True}"/>-->
                     <field
                         name="stage_id"
                         string="Ticket Stage"


### PR DESCRIPTION
Proposing again a fix that was already proposed for `14.0` in https://github.com/OCA/helpdesk/pull/593 and https://github.com/OCA/helpdesk/pull/404, and for `16.0` in https://github.com/OCA/helpdesk/pull/921 (including a test :rocket:) hoping the 4th time's the charm :four_leaf_clover:

---

This commit reviews the security rules around the fsm_order_close_wizard.

The "Complete" button on the fsm.order triggered an access error for fieldservice.group_fsm_user_own. The commit allows fieldservice.group_fsm_user_own to use the wizard as well. However, the wizard is now only shown if the user also has write permission on the specific ticket (so as to play nice with a variety of setups, including helpdesk_mgmt.group_helpdesk_user_own).

If the user has permission to write on the ticket, the wizard will be shown as before; otherwise it will simply be skipped, but the fsm.order will be closed as it should.

There's also some code cleanup on the wizard, such as removing the unused team_id field.