### PR TITLE
[FIX] helpdesk_mgmt_crm: ensure attachments on created leads are readable to people without helpdesk access.

### DIFF
--- a/helpdesk_mgmt_crm/tests/test_helpdesk_mgmt_crm.py
+++ b/helpdesk_mgmt_crm/tests/test_helpdesk_mgmt_crm.py
@@ -2,6 +2,9 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 
+from markupsafe import Markup
+
+from odoo.exceptions import AccessError
 from odoo.tests import common
 from odoo.tests.common import new_test_user, users
 
@@ -18,6 +21,10 @@ class TestHelpdeskMgmtCrm(common.TransactionCase):
         )
         cls.user2 = new_test_user(
             cls.env, login="sale-user2", groups="sales_team.group_sale_salesman"
+        )
+        # Sees every lead, but has no helpdesk access at all.
+        cls.user3 = new_test_user(
+            cls.env, login="sale-manager", groups="sales_team.group_sale_manager"
         )
         cls.team = cls.env["crm.team"].create(
             {"name": "Test team", "member_ids": [(6, 0, [cls.user2.id])]}
@@ -75,3 +82,47 @@ class TestHelpdeskMgmtCrm(common.TransactionCase):
         res = self.ticket.action_open_leads()
         self.assertEqual(res["res_model"], self.ticket.lead_ids._name)
         self.assertEqual(res["res_id"], self.ticket.lead_ids.id)
+
+    @users("sale-user")
+    def test_action_lead_create_attachments(self):
+        attachment = self.env["ir.attachment"].create(
+            {
+                "name": "image.png",
+                "raw": b"an image",
+                "res_model": self.ticket._name,
+                "res_id": self.ticket.id,
+            }
+        )
+        self.ticket.message_post(
+            body=Markup('<p><img src="/web/image/%s"></p>') % attachment.id,
+            attachment_ids=attachment.ids,
+            subtype_xmlid="mail.mt_comment",
+        )
+        wizard = (
+            self.env["helpdesk.ticket.create.lead"]
+            .with_context(active_id=self.ticket.id)
+            .create({"team_id": self.team.id})
+        )
+        wizard.action_helpdesk_ticket_to_lead()
+        lead = self.ticket.lead_ids
+        new_message = lead.message_ids.filtered("attachment_ids")
+        self.assertEqual(len(new_message), 1)
+        new_attachment = new_message.attachment_ids
+        self.assertEqual(len(new_attachment), 1)
+        # The lead got its own copy, attached to the lead itself.
+        self.assertNotEqual(new_attachment, attachment)
+        self.assertEqual(new_attachment.res_model, lead._name)
+        self.assertEqual(new_attachment.res_id, lead.id)
+        self.assertEqual(new_attachment.raw, attachment.raw)
+        # The ticket keeps the original.
+        self.assertEqual(attachment.res_model, self.ticket._name)
+        self.assertEqual(attachment.res_id, self.ticket.id)
+        # The inline image in the body points at the copy.
+        self.assertIn("/web/image/%s" % new_attachment.id, new_message.body)
+        self.assertNotIn("/web/image/%s" % attachment.id, new_message.body)
+        # A user who can see the lead but not the ticket can read the copy,
+        # which is the whole point: they used to get a placeholder image.
+        lead.with_user(self.user3).check_access_rule("read")
+        new_attachment.with_user(self.user3).check("read")
+        with self.assertRaises(AccessError):
+            attachment.with_user(self.user3).check("read")

--- a/helpdesk_mgmt_crm/wizard/helpdesk_ticket_create_lead.py
+++ b/helpdesk_mgmt_crm/wizard/helpdesk_ticket_create_lead.py
@@ -1,9 +1,15 @@
 # Copyright 2022-2025 Tecnativa - Víctor Martínez
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
+import re
+
 from markupsafe import Markup
 
 from odoo import SUPERUSER_ID, _, api, fields, models
+
+# Inline images in a message body are served by id, as /web/image/<id> or
+# /web/content/<id>, optionally followed by a filename and a query string.
+ATTACHMENT_URL_RE = re.compile(r"/web/(image|content)/(\d+)")
 
 
 class HelpdeskTicketCreateLead(models.TransientModel):
@@ -38,6 +44,46 @@ class HelpdeskTicketCreateLead(models.TransientModel):
             "type": "opportunity",
         }
 
+    def _copy_message_attachments(self, message, new_message):
+        """Give the message copied to the lead its own attachments.
+
+        ``mail.message.attachment_ids`` is a many2many, so copying a message
+        leaves the copy pointing at the *same* ``ir.attachment`` records, which
+        stay attached to the ticket. An attachment has no access rules of its
+        own: reading one checks read access on the record named by its
+        ``res_model``/``res_id``. So a salesperson who can see the lead but not
+        the ticket gets an ``AccessError`` for every file of the copied
+        chatter, which the ``/web/image`` route answers with a placeholder
+        image instead of the picture.
+
+        Copy the attachments onto the lead so the copy stands on its own. The
+        ticket keeps its originals, and deleting either record no longer takes
+        the other one's files with it.
+        """
+        id_map = {}
+        new_attachments = self.env["ir.attachment"]
+        for attachment in message.attachment_ids:
+            copied = attachment.copy(
+                {"res_model": new_message.model, "res_id": new_message.res_id}
+            )
+            id_map[attachment.id] = copied.id
+            new_attachments |= copied
+        if not id_map:
+            return
+        vals = {"attachment_ids": [fields.Command.set(new_attachments.ids)]}
+        # Inline images name their attachment by id in the body, so the body
+        # has to follow the copies. Their access token is copied along with the
+        # attachment, which keeps the rest of the URL valid.
+        body = new_message.body or ""
+        new_body = ATTACHMENT_URL_RE.sub(
+            lambda match: "/web/%s/%s"
+            % (match.group(1), id_map.get(int(match.group(2)), match.group(2))),
+            body,
+        )
+        if new_body != body:
+            vals["body"] = new_body
+        new_message.write(vals)
+
     def action_helpdesk_ticket_to_lead(self):
         lead = self.env["crm.lead"].create(self._prepare_vals())
         for follower in self.ticket_id.message_follower_ids:
@@ -47,7 +93,7 @@ class HelpdeskTicketCreateLead(models.TransientModel):
             )
         self.ticket_id.write({"lead_ids": [(4, lead.id)]})
         for message in self.ticket_id.message_ids:
-            message.copy(
+            new_message = message.copy(
                 {
                     "model": lead._name,
                     "res_id": lead.id,
@@ -56,6 +102,7 @@ class HelpdeskTicketCreateLead(models.TransientModel):
                     "notified_partner_ids": False,
                 }
             )
+            self._copy_message_attachments(message, new_message)
         # Chatter reflects new Lead
         body = Markup(
             _("This ticket has been converted to the opportunity %(lead_link)s")


### PR DESCRIPTION
When creating a lead from a ticket, the new mail.messages point to the same ir.attachments as the old
messages. Those are still associated to a ticket, so users that dont' have helpdesk permissions cannot
see them.

This fixes it by creating a new ir.attachment associated to the crm.lead. This doesn't duplicate
the data on disk, both point to the same file.
